### PR TITLE
Remove problematic inline numbered list detection regex

### DIFF
--- a/components/ui/MarkdownPreview.tsx
+++ b/components/ui/MarkdownPreview.tsx
@@ -34,9 +34,7 @@ export const MarkdownPreview = ({ content, className = '' }: MarkdownPreviewProp
       // Fix multiple bullet points on same line
       .replace(/([•·▸▹►]\s*[^•\n]+)([•·▸▹►])/g, '$1\n$2')
       // Ensure there's a blank line before first bullet after text
-      .replace(/([^\n])(\n[•·▸▹►])/g, '$1\n$2')
-      // Fix numbered lists that might be inline (but skip those starting with bold)
-      .replace(/([^\n])\s*(?<!\*\*)(\d+[.)]\s)/g, '$1\n\n$2');
+      .replace(/([^\n])(\n[•·▸▹►])/g, '$1\n$2');
     
     // Convert bullet characters to proper markdown list syntax
     processed = processed


### PR DESCRIPTION
- Removed regex that was splitting text like 'Test 6.' in the middle of sentences
- This was causing the next line's bullet point to be misinterpreted as a numbered list
- Fixes issue where bullet points after sentences containing 'Test 6.' were showing as '1. • **text**'
- Now inline references like 'Test 6.' remain inline without breaking formatting