### PR TITLE
Fix null mapping error in semantic SEO audit workflow

### DIFF
--- a/components/ui/AgenticSemanticAuditor.tsx
+++ b/components/ui/AgenticSemanticAuditor.tsx
@@ -146,7 +146,7 @@ export const AgenticSemanticAuditor = ({
             setProgress(data);
             
             // Log audit updates
-            if (data.session.status === 'auditing') {
+            if (data.session.status === 'auditing' && data.sections && Array.isArray(data.sections)) {
               const currentSection = data.sections.find((s: AuditSection) => s.status === 'auditing');
               if (currentSection) {
                 addLog(`Auditing section ${currentSection.sectionNumber}: "${currentSection.title}"`);
@@ -242,7 +242,7 @@ export const AgenticSemanticAuditor = ({
     }
   };
 
-  const progressPercentage = progress 
+  const progressPercentage = progress && progress.progress && progress.progress.total > 0
     ? Math.round((progress.progress.completed / progress.progress.total) * 100) 
     : 0;
 
@@ -312,7 +312,7 @@ export const AgenticSemanticAuditor = ({
           </div>
 
           {/* Sections List */}
-          {progress.sections.length > 0 && (
+          {progress.sections && Array.isArray(progress.sections) && progress.sections.length > 0 && (
             <div className="space-y-2">
               <h4 className="font-medium text-gray-900">Article Sections</h4>
               <div className="space-y-2 max-h-60 overflow-y-auto">

--- a/lib/services/agenticSemanticAuditService.ts
+++ b/lib/services/agenticSemanticAuditService.ts
@@ -592,7 +592,7 @@ START AUDITING THE NEXT SECTION NOW - DO NOT ASK FOR PERMISSION OR CONFIRMATION.
 
     return {
       session,
-      sections,
+      sections: sections || [], // Ensure sections is always an array
       progress: {
         total: session.totalSections || 0,
         completed: session.completedSections || 0,


### PR DESCRIPTION
- Added defensive null checks for progress.sections to prevent TypeError
- Check if sections exists and is an array before accessing length or mapping
- Added safeguard in getAuditProgress to ensure sections is always an array
- Added null check for progress.progress.total to prevent division by zero
- Fixes the 'Cannot read properties of null (reading map)' error that was causing the agent workflow to hang