### PR TITLE
Add column size check page for database diagnostics

### DIFF
--- a/app/admin/column-check/page.tsx
+++ b/app/admin/column-check/page.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+export default function ColumnCheckPage() {
+  const [columnInfo, setColumnInfo] = useState<string>('');
+  const [loading, setLoading] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState('');
+
+  const fetchColumnInfo = async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const response = await fetch('/api/admin/check-column-sizes');
+      if (!response.ok) throw new Error('Failed to fetch column info');
+      const text = await response.text();
+      setColumnInfo(text);
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchColumnInfo();
+  }, []);
+
+  const copyToClipboard = () => {
+    navigator.clipboard.writeText(columnInfo);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-8">
+      <div className="max-w-4xl mx-auto">
+        <div className="bg-white rounded-lg shadow-lg p-6">
+          <div className="flex items-center justify-between mb-6">
+            <h1 className="text-2xl font-bold text-gray-900">Database Column Size Check</h1>
+            <div className="flex gap-2">
+              <button
+                onClick={fetchColumnInfo}
+                disabled={loading}
+                className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+              >
+                {loading ? 'Loading...' : 'Refresh'}
+              </button>
+              <button
+                onClick={copyToClipboard}
+                disabled={!columnInfo}
+                className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700 disabled:opacity-50"
+              >
+                {copied ? '✓ Copied!' : 'Copy All'}
+              </button>
+            </div>
+          </div>
+
+          {error && (
+            <div className="mb-4 p-4 bg-red-50 border border-red-200 rounded-lg">
+              <span className="text-red-700">Error: {error}</span>
+            </div>
+          )}
+          
+          <div className="bg-gray-100 rounded-lg p-4 mb-6">
+            <pre className="whitespace-pre-wrap text-sm font-mono text-gray-800">
+              {loading ? 'Loading column information...' : columnInfo || 'No data available'}
+            </pre>
+          </div>
+          
+          <div className="p-4 bg-blue-50 border border-blue-200 rounded-lg">
+            <h3 className="font-semibold text-blue-900 mb-2">Quick Actions:</h3>
+            <div className="space-y-3 text-sm">
+              <div>
+                <strong>If polish_approach is varchar(100):</strong>
+                <button
+                  onClick={() => {
+                    fetch('/api/admin/fix-polish-approach-column', { method: 'POST' })
+                      .then(r => r.json())
+                      .then(d => {
+                        alert(JSON.stringify(d, null, 2));
+                        if (d.success) fetchColumnInfo();
+                      });
+                  }}
+                  className="ml-2 px-3 py-1 bg-red-600 text-white rounded text-xs hover:bg-red-700"
+                >
+                  Fix Column Sizes
+                </button>
+              </div>
+              <div>
+                <strong>API Endpoint:</strong>
+                <code className="ml-2 px-2 py-1 bg-gray-200 rounded text-xs">/api/admin/check-column-sizes</code>
+              </div>
+              <div>
+                <strong>This page URL:</strong>
+                <code className="ml-2 px-2 py-1 bg-gray-200 rounded text-xs">/admin/column-check</code>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/api/admin/check-column-sizes/route.ts
+++ b/app/api/admin/check-column-sizes/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db/connection';
+import { sql } from 'drizzle-orm';
+
+export async function GET() {
+  try {
+    console.log('Checking column sizes for all varchar columns...');
+    
+    // Get all varchar columns and their sizes
+    const columnInfo = await db.execute(sql`
+      SELECT 
+        table_name,
+        column_name,
+        data_type,
+        character_maximum_length,
+        is_nullable,
+        column_default
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+      AND table_name IN ('polish_sessions', 'polish_sections', 'audit_sessions', 'audit_sections')
+      AND (data_type = 'character varying' OR data_type LIKE 'varchar%')
+      ORDER BY table_name, ordinal_position
+    `);
+    
+    // Format the results for easy copying
+    const formattedResults = (columnInfo as any).rows?.map((col: any) => ({
+      table: col.table_name,
+      column: col.column_name,
+      type: col.data_type,
+      max_length: col.character_maximum_length,
+      nullable: col.is_nullable,
+      default: col.column_default
+    })) || columnInfo;
+    
+    // Group by table
+    const byTable: Record<string, any[]> = {};
+    formattedResults.forEach((col: any) => {
+      if (!byTable[col.table]) byTable[col.table] = [];
+      byTable[col.table].push(col);
+    });
+    
+    // Create a text summary
+    let textSummary = "=== VARCHAR COLUMN SIZES ===\n\n";
+    
+    Object.entries(byTable).forEach(([table, columns]) => {
+      textSummary += `TABLE: ${table}\n`;
+      textSummary += "─".repeat(50) + "\n";
+      columns.forEach((col: any) => {
+        textSummary += `  ${col.column}: varchar(${col.max_length || 'unlimited'})\n`;
+      });
+      textSummary += "\n";
+    });
+    
+    // Check specific problematic columns
+    textSummary += "=== SPECIFIC COLUMNS TO CHECK ===\n\n";
+    
+    const problemColumns = [
+      { table: 'polish_sections', column: 'polish_approach', expected: 255 },
+      { table: 'polish_sections', column: 'title', expected: 500 },
+      { table: 'audit_sections', column: 'editing_pattern', expected: 100 },
+      { table: 'audit_sections', column: 'title', expected: 255 }
+    ];
+    
+    for (const check of problemColumns) {
+      const result = formattedResults.find((col: any) => 
+        col.table === check.table && col.column === check.column
+      );
+      
+      if (result) {
+        const status = result.max_length >= check.expected ? "✅ OK" : "❌ TOO SMALL";
+        textSummary += `${check.table}.${check.column}: varchar(${result.max_length}) - Expected: varchar(${check.expected}) ${status}\n`;
+      } else {
+        textSummary += `${check.table}.${check.column}: NOT FOUND\n`;
+      }
+    }
+    
+    // Return both JSON and text
+    return new NextResponse(textSummary, {
+      headers: {
+        'Content-Type': 'text/plain; charset=utf-8',
+      },
+    });
+    
+  } catch (error: any) {
+    console.error('Error checking column sizes:', error);
+    return NextResponse.json({
+      error: 'Failed to check column sizes',
+      details: error.message
+    }, { status: 500 });
+  }
+}


### PR DESCRIPTION
- Created /admin/column-check page to display all varchar column sizes
- Shows formatted text output for easy copy/paste
- Highlights problematic columns that need fixing
- Includes quick fix button for polish_approach column issue
- API endpoint at /api/admin/check-column-sizes returns plain text

This helps diagnose varchar limit issues like the polish_approach varchar(100) problem.

🤖 Generated with [Claude Code](https://claude.ai/code)