### PR TITLE
Fix TypeScript error in diagnostics API

### DIFF
--- a/app/api/admin/comprehensive-diagnostics/route.ts
+++ b/app/api/admin/comprehensive-diagnostics/route.ts
@@ -159,7 +159,7 @@ export async function GET(request: NextRequest) {
         totalRows: workflowStepsCount.rows[0].count
       };
 
-      if (parseInt(workflowStepsCount.rows[0].count) > 0) {
+      if (parseInt(String(workflowStepsCount.rows[0].count)) > 0) {
         const sampleStep = await db.execute(sql`
           SELECT * FROM workflow_steps LIMIT 1
         `);


### PR DESCRIPTION
Fixed parseInt() type error by casting to string first. Build now passes successfully.