### PR TITLE
Add targeted fix for formatting QA insert errors

### DIFF
--- a/app/admin/fix-formatting-qa/page.tsx
+++ b/app/admin/fix-formatting-qa/page.tsx
@@ -1,0 +1,269 @@
+'use client';
+
+import React, { useState } from 'react';
+import { AlertTriangle, CheckCircle, XCircle, Wrench, Play, Database } from 'lucide-react';
+
+export default function FixFormattingQAPage() {
+  const [diagnosis, setDiagnosis] = useState<any>(null);
+  const [fixResults, setFixResults] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [fixing, setFixing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const runDiagnosis = async () => {
+    setLoading(true);
+    setError(null);
+    setDiagnosis(null);
+
+    try {
+      const response = await fetch('/api/admin/fix-formatting-qa-columns');
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      const data = await response.json();
+      setDiagnosis(data);
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const fixColumns = async () => {
+    setFixing(true);
+    setError(null);
+    setFixResults(null);
+
+    try {
+      const response = await fetch('/api/admin/fix-formatting-qa-columns', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ action: 'fix_all_columns' })
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const data = await response.json();
+      setFixResults(data);
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setFixing(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-8">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="bg-white rounded-lg shadow p-6">
+          <div className="flex items-center justify-between mb-6">
+            <div className="flex items-center space-x-3">
+              <Wrench className="w-8 h-8 text-red-600" />
+              <h1 className="text-2xl font-bold text-gray-900">Fix Formatting QA Insert Errors</h1>
+            </div>
+            
+            <div className="flex space-x-3">
+              <button
+                onClick={runDiagnosis}
+                disabled={loading}
+                className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md flex items-center disabled:opacity-50"
+              >
+                <Database className={`w-4 h-4 mr-2 ${loading ? 'animate-spin' : ''}`} />
+                {loading ? 'Diagnosing...' : 'Diagnose Issue'}
+              </button>
+              
+              {diagnosis && diagnosis.issues.length > 0 && (
+                <button
+                  onClick={fixColumns}
+                  disabled={fixing}
+                  className="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-md flex items-center disabled:opacity-50"
+                >
+                  <Wrench className={`w-4 h-4 mr-2 ${fixing ? 'animate-spin' : ''}`} />
+                  {fixing ? 'Fixing...' : 'Fix All Columns'}
+                </button>
+              )}
+            </div>
+          </div>
+
+          <div className="mb-6 bg-yellow-50 border border-yellow-200 rounded-lg p-4">
+            <div className="flex items-start space-x-3">
+              <AlertTriangle className="w-5 h-5 text-yellow-600 mt-0.5" />
+              <div>
+                <h3 className="text-sm font-semibold text-yellow-800">Issue Description</h3>
+                <p className="text-sm text-yellow-700 mt-1">
+                  The formatting QA feature is failing with "Failed query: insert into formatting_qa_checks" errors.
+                  This is caused by VARCHAR column size limits being exceeded by AI-generated content.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {error && (
+            <div className="mb-6 bg-red-50 border border-red-200 rounded-lg p-4">
+              <div className="flex items-center space-x-2">
+                <XCircle className="w-5 h-5 text-red-600" />
+                <span className="text-red-800">Error: {error}</span>
+              </div>
+            </div>
+          )}
+
+          {diagnosis && (
+            <div className="space-y-6">
+              {/* Current Schema */}
+              <div className="border border-gray-200 rounded-lg p-6">
+                <h2 className="text-lg font-semibold text-gray-900 mb-4">Current Schema</h2>
+                <div className="overflow-x-auto">
+                  <table className="min-w-full divide-y divide-gray-200">
+                    <thead className="bg-gray-50">
+                      <tr>
+                        <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Column</th>
+                        <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
+                        <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Max Length</th>
+                        <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                      </tr>
+                    </thead>
+                    <tbody className="bg-white divide-y divide-gray-200">
+                      {diagnosis.currentSchema.map((col: any, idx: number) => (
+                        <tr key={idx}>
+                          <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                            {col.column_name}
+                          </td>
+                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                            {col.data_type}
+                          </td>
+                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                            {col.character_maximum_length || 'N/A'}
+                          </td>
+                          <td className="px-6 py-4 whitespace-nowrap text-sm">
+                            {diagnosis.issues.find((i: any) => i.column === col.column_name) ? (
+                              <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800">
+                                Issues
+                              </span>
+                            ) : (
+                              <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                                OK
+                              </span>
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+
+              {/* Issues Found */}
+              {diagnosis.issues.length > 0 && (
+                <div className="border border-red-200 rounded-lg p-6">
+                  <h2 className="text-lg font-semibold text-gray-900 mb-4">Issues Found ({diagnosis.issues.length})</h2>
+                  <div className="space-y-4">
+                    {diagnosis.issues.map((issue: any, idx: number) => (
+                      <div key={idx} className="bg-red-50 border border-red-200 rounded p-4">
+                        <div className="flex items-start space-x-3">
+                          <XCircle className="w-5 h-5 text-red-600 mt-0.5" />
+                          <div className="flex-1">
+                            <div className="font-semibold text-red-900">{issue.column}</div>
+                            <div className="text-sm text-red-800 mt-1">
+                              <strong>Current:</strong> {issue.current}
+                            </div>
+                            <div className="text-sm text-red-800">
+                              <strong>Problem:</strong> {issue.problem}
+                            </div>
+                            <div className="text-sm text-red-800">
+                              <strong>Fix:</strong> {issue.fix}
+                            </div>
+                            {issue.testValue && (
+                              <details className="mt-2">
+                                <summary className="text-sm text-red-700 cursor-pointer">Show failing data</summary>
+                                <div className="mt-2 text-xs bg-red-100 p-2 rounded font-mono">
+                                  {issue.testValue}
+                                </div>
+                              </details>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {diagnosis.issues.length === 0 && (
+                <div className="bg-green-50 border border-green-200 rounded-lg p-6">
+                  <div className="flex items-center space-x-3">
+                    <CheckCircle className="w-8 h-8 text-green-600" />
+                    <div>
+                      <h3 className="text-lg font-semibold text-green-800">No Issues Found</h3>
+                      <p className="text-sm text-green-700 mt-1">
+                        All columns appear to be properly configured. The issue may be elsewhere.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {fixResults && (
+            <div className="mt-6 border border-green-200 rounded-lg p-6">
+              <h2 className="text-lg font-semibold text-gray-900 mb-4">Fix Results</h2>
+              <div className="space-y-3">
+                {fixResults.results.map((result: any, idx: number) => (
+                  <div key={idx} className={`p-3 rounded ${
+                    result.success ? 'bg-green-50 border border-green-200' : 'bg-red-50 border border-red-200'
+                  }`}>
+                    <div className="flex items-start space-x-3">
+                      {result.success ? (
+                        <CheckCircle className="w-5 h-5 text-green-600 mt-0.5" />
+                      ) : (
+                        <XCircle className="w-5 h-5 text-red-600 mt-0.5" />
+                      )}
+                      <div className="flex-1">
+                        <div className="font-medium">
+                          {result.step === 'test_insert' ? 'Test Insert' : 
+                           result.step === 'current_schema' ? 'Current Schema' :
+                           result.step === 'new_schema' ? 'New Schema' :
+                           result.column}
+                        </div>
+                        <div className="text-sm text-gray-600 mt-1">
+                          {result.message || result.error}
+                        </div>
+                        {result.sql && (
+                          <div className="text-xs font-mono bg-gray-100 p-2 rounded mt-2">
+                            {result.sql}
+                          </div>
+                        )}
+                        {result.data && (
+                          <details className="mt-2">
+                            <summary className="text-sm cursor-pointer">Show data</summary>
+                            <pre className="text-xs bg-gray-100 p-2 rounded mt-2 overflow-x-auto">
+                              {JSON.stringify(result.data, null, 2)}
+                            </pre>
+                          </details>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Navigation */}
+          <div className="mt-8 pt-6 border-t border-gray-200">
+            <a
+              href="/admin/database-migration"
+              className="inline-flex items-center text-sm text-blue-600 hover:text-blue-700"
+            >
+              ← Back to Database Migration
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/api/admin/fix-formatting-qa-columns/route.ts
+++ b/app/api/admin/fix-formatting-qa-columns/route.ts
@@ -1,0 +1,245 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/lib/db/connection';
+import { sql } from 'drizzle-orm';
+
+export async function GET(request: NextRequest) {
+  try {
+    const diagnosis: any = {
+      timestamp: new Date().toISOString(),
+      currentSchema: {},
+      issues: [],
+      fixes: []
+    };
+
+    // Get current schema for formatting_qa_checks table
+    const currentSchema = await db.execute(sql`
+      SELECT 
+        column_name,
+        data_type,
+        character_maximum_length,
+        is_nullable,
+        column_default
+      FROM information_schema.columns
+      WHERE table_schema = 'public' 
+      AND table_name = 'formatting_qa_checks'
+      ORDER BY ordinal_position
+    `);
+
+    diagnosis.currentSchema = currentSchema.rows;
+
+    // Analyze the failing insert from the error message
+    const problematicColumns = [
+      'check_description',
+      'issues_found', 
+      'location_details',
+      'fix_suggestions',
+      'check_metadata'
+    ];
+
+    const textColumns = ['check_description', 'issues_found', 'location_details', 'fix_suggestions'];
+    const jsonColumns = ['check_metadata'];
+
+    for (const col of currentSchema.rows) {
+      if (problematicColumns.includes(String(col.column_name))) {
+        if (textColumns.includes(String(col.column_name))) {
+          if (col.data_type === 'character varying' && col.character_maximum_length) {
+            diagnosis.issues.push({
+              column: col.column_name,
+              current: `VARCHAR(${col.character_maximum_length})`,
+              problem: `Text content exceeds ${col.character_maximum_length} characters`,
+              fix: 'Change to TEXT'
+            });
+          }
+        } else if (jsonColumns.includes(String(col.column_name))) {
+          if (col.data_type !== 'jsonb') {
+            diagnosis.issues.push({
+              column: col.column_name,
+              current: col.data_type,
+              problem: 'Should be JSONB for JSON data',
+              fix: 'Change to JSONB'
+            });
+          }
+        }
+      }
+    }
+
+    // Test the exact failing data
+    const testData = {
+      check_description: 'Ensure all required sections exist: Intro, body, FAQ intro, Conclusion',
+      issues_found: '',
+      location_details: '',
+      fix_suggestions: 'No action required – section structure is complete.',
+      check_metadata: {
+        analysis: 'The article contains: Intro ("Introduction – why …"), multiple body sections (Tier 1, Tier 2, Tier 3, decision checklist), FAQ section with intro heading, Conclusion, and an additional quick-reference appendix. All required sections are present.',
+        issueCount: 0
+      }
+    };
+
+    // Check if this data would fit in current schema
+    for (const [key, value] of Object.entries(testData)) {
+      const column = currentSchema.rows.find(c => c.column_name === key);
+      if (column && column.data_type === 'character varying' && column.character_maximum_length) {
+        const valueLength = typeof value === 'string' ? value.length : JSON.stringify(value).length;
+        if (valueLength > Number(column.character_maximum_length)) {
+          diagnosis.issues.push({
+            column: key,
+            current: `VARCHAR(${column.character_maximum_length})`,
+            problem: `Test data is ${valueLength} chars, exceeds limit of ${column.character_maximum_length}`,
+            fix: 'Change to TEXT',
+            testValue: typeof value === 'string' ? value : JSON.stringify(value)
+          });
+        }
+      }
+    }
+
+    return NextResponse.json(diagnosis, { status: 200 });
+
+  } catch (error: any) {
+    return NextResponse.json({
+      error: 'Diagnosis failed',
+      details: error.message,
+      stack: error.stack
+    }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const { action } = await request.json();
+    
+    if (action === 'fix_all_columns') {
+      const results = [];
+      
+      // First, let's check what we're working with
+      const currentSchema = await db.execute(sql`
+        SELECT column_name, data_type, character_maximum_length
+        FROM information_schema.columns
+        WHERE table_schema = 'public' 
+        AND table_name = 'formatting_qa_checks'
+        AND column_name IN ('check_description', 'issues_found', 'location_details', 'fix_suggestions', 'check_metadata')
+      `);
+      
+      results.push({ step: 'current_schema', data: currentSchema.rows });
+      
+      // Fix each column individually with specific SQL
+      const fixes = [
+        {
+          column: 'check_description',
+          sql: `ALTER TABLE formatting_qa_checks ALTER COLUMN check_description TYPE TEXT`
+        },
+        {
+          column: 'issues_found', 
+          sql: `ALTER TABLE formatting_qa_checks ALTER COLUMN issues_found TYPE TEXT`
+        },
+        {
+          column: 'location_details',
+          sql: `ALTER TABLE formatting_qa_checks ALTER COLUMN location_details TYPE TEXT`
+        },
+        {
+          column: 'fix_suggestions',
+          sql: `ALTER TABLE formatting_qa_checks ALTER COLUMN fix_suggestions TYPE TEXT`
+        },
+        {
+          column: 'check_metadata',
+          sql: `ALTER TABLE formatting_qa_checks ALTER COLUMN check_metadata TYPE JSONB USING check_metadata::jsonb`
+        }
+      ];
+      
+      for (const fix of fixes) {
+        try {
+          await db.execute(sql.raw(fix.sql));
+          results.push({ 
+            column: fix.column, 
+            success: true, 
+            sql: fix.sql,
+            message: 'Column altered successfully'
+          });
+        } catch (error: any) {
+          results.push({ 
+            column: fix.column, 
+            success: false, 
+            sql: fix.sql,
+            error: error.message 
+          });
+        }
+      }
+      
+      // Verify the changes
+      const newSchema = await db.execute(sql`
+        SELECT column_name, data_type, character_maximum_length
+        FROM information_schema.columns
+        WHERE table_schema = 'public' 
+        AND table_name = 'formatting_qa_checks'
+        AND column_name IN ('check_description', 'issues_found', 'location_details', 'fix_suggestions', 'check_metadata')
+      `);
+      
+      results.push({ step: 'new_schema', data: newSchema.rows });
+      
+      // Test insert with the exact failing data
+      try {
+        const testId = 'test-' + Date.now();
+        await db.execute(sql`
+          INSERT INTO formatting_qa_checks (
+            id, qa_session_id, workflow_id, version, check_number, 
+            check_type, check_description, status, issues_found, 
+            location_details, confidence_score, fix_suggestions, 
+            check_metadata, created_at, updated_at
+          ) VALUES (
+            ${testId},
+            'test-session',
+            'test-workflow', 
+            1,
+            3,
+            'section_completeness',
+            'Ensure all required sections exist: Intro, body, FAQ intro, Conclusion',
+            'passed',
+            '',
+            '',
+            8.5,
+            'No action required – section structure is complete.',
+            ${{
+              analysis: 'The article contains: Intro ("Introduction – why …"), multiple body sections (Tier 1, Tier 2, Tier 3, decision checklist), FAQ section with intro heading, Conclusion, and an additional quick-reference appendix. All required sections are present.',
+              issueCount: 0
+            }},
+            NOW(),
+            NOW()
+          )
+        `);
+        
+        // Clean up test data
+        await db.execute(sql`DELETE FROM formatting_qa_checks WHERE id = ${testId}`);
+        
+        results.push({ 
+          step: 'test_insert', 
+          success: true, 
+          message: 'Test insert successful - issue should be fixed!'
+        });
+        
+      } catch (error: any) {
+        results.push({ 
+          step: 'test_insert', 
+          success: false, 
+          error: error.message,
+          message: 'Test insert still failing'
+        });
+      }
+      
+      return NextResponse.json({
+        success: true,
+        message: 'Column fix operation completed',
+        results
+      });
+    }
+    
+    return NextResponse.json({ 
+      error: 'Invalid action' 
+    }, { status: 400 });
+
+  } catch (error: any) {
+    return NextResponse.json({
+      error: 'Fix operation failed',
+      details: error.message,
+      stack: error.stack
+    }, { status: 500 });
+  }
+}


### PR DESCRIPTION
Created specific diagnostic and fix tools for the exact insert error:
- /admin/fix-formatting-qa - Page to diagnose and fix the exact issue
- /api/admin/fix-formatting-qa-columns - API that:
  - Analyzes current schema with exact failing data
  - Tests the exact INSERT that's failing
  - Fixes specific columns: check_description, issues_found, location_details, fix_suggestions, check_metadata
  - Runs test insert to verify the fix works

This addresses the specific 'Failed query: insert into formatting_qa_checks' error by changing VARCHAR columns to TEXT/JSONB.