### PR TITLE
Fix formatting QA results persistence - data now survives page refresh

### DIFF
--- a/app/api/workflows/[id]/formatting-qa/latest/route.ts
+++ b/app/api/workflows/[id]/formatting-qa/latest/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { agenticFormattingQAService } from '@/lib/services/agenticFormattingQAService';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    console.log('Getting latest formatting QA session for workflow:', id);
+    
+    const latestSession = await agenticFormattingQAService.getLatestQASession(id);
+    
+    if (!latestSession) {
+      return NextResponse.json({
+        success: true,
+        session: null,
+        message: 'No QA session found for this workflow'
+      });
+    }
+    
+    console.log('Found latest QA session:', latestSession.id);
+    
+    return NextResponse.json({
+      success: true,
+      session: latestSession
+    });
+    
+  } catch (error: any) {
+    console.error('Error getting latest formatting QA session:', error);
+    return NextResponse.json({
+      success: false,
+      error: error.message
+    }, { status: 500 });
+  }
+}


### PR DESCRIPTION
- Add /api/workflows/[id]/formatting-qa/latest endpoint to get latest session
- Add useEffect to AgenticFormattingChecker to load existing sessions on mount
- Show loading indicator while fetching existing sessions
- Update button text to "Run Again" when session exists
- Display progress stats for existing sessions
- Restore all session data: status, checks, cleaned article, fixes applied
- Fix service import name and Next.js route parameters

Now when users refresh the page or navigate back, all their formatting QA results including the cleaned article and fixes will be preserved and displayed.

🤖 Generated with [Claude Code](https://claude.ai/code)