### PR TITLE
Add markup rendering to formatting QA module for visualizing cleaned …

### DIFF
--- a/components/ui/AgenticFormattingChecker.tsx
+++ b/components/ui/AgenticFormattingChecker.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect, useRef } from 'react';
 import { Bot, CheckCircle, AlertCircle, XCircle, Clock, FileText, AlertTriangle, Copy } from 'lucide-react';
+import { MarkdownPreview } from './MarkdownPreview';
 
 interface AgenticFormattingCheckerProps {
   workflowId: string;
@@ -514,12 +515,30 @@ export function AgenticFormattingChecker({ workflowId, onComplete }: AgenticForm
             </div>
           )}
 
-          {/* Article Preview */}
-          <div className="border border-gray-200 rounded-lg p-4 max-h-96 overflow-y-auto">
-            <div className="prose prose-sm max-w-none">
-              <div className="whitespace-pre-wrap text-gray-700 leading-relaxed">
-                {cleanedArticle}
-              </div>
+          {/* Article Preview with Dual View */}
+          <div className="space-y-4">
+            {/* Raw Markdown View */}
+            <div className="space-y-2">
+              <label className="block text-sm font-medium text-gray-700">
+                Cleaned Article (Markdown)
+              </label>
+              <textarea
+                value={cleanedArticle}
+                readOnly
+                className="w-full h-64 p-3 border border-gray-300 rounded-lg bg-gray-50 text-sm font-mono resize-none"
+                placeholder="The cleaned article will appear here..."
+              />
+            </div>
+            
+            {/* Rendered Preview */}
+            <div className="space-y-2">
+              <label className="block text-sm font-medium text-gray-700">
+                Formatted Preview
+              </label>
+              <MarkdownPreview 
+                content={cleanedArticle}
+                className="border border-gray-300 rounded-lg"
+              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
…articles

- Import MarkdownPreview component to AgenticFormattingChecker
- Replace plain text display with dual view: raw markdown + rendered preview
- Add proper labels for "Cleaned Article (Markdown)" and "Formatted Preview"
- Follow same pattern as semantic SEO and polish modules
- Users can now see formatted headings, lists, links, and styling in cleaned articles
- Maintains copy functionality for raw markdown

Now formatting QA module has same rich preview capabilities as other modules, allowing users to visualize exactly how their cleaned articles will look.

🤖 Generated with [Claude Code](https://claude.ai/code)