### PR TITLE
Fix infinite loop in Formatting QA session loading

### DIFF
--- a/components/steps/FormattingQAStepClean.tsx
+++ b/components/steps/FormattingQAStepClean.tsx
@@ -20,13 +20,16 @@ export const FormattingQAStepClean = ({ step, workflow, onChange }: FormattingQA
   const googleDocUrl = articleDraftStep?.outputs?.googleDocUrl || '';
 
   const handleAgenticComplete = (qaReport: any) => {
-    // Save the QA report results
-    onChange({
-      ...step.outputs,
-      agenticQACompleted: true,
-      agenticQAReport: qaReport,
-      lastQASessionId: qaReport.id
-    });
+    // Only update if the session ID has changed to prevent loops
+    if (qaReport.sessionId && qaReport.sessionId !== step.outputs?.lastQASessionId) {
+      // Save the QA report results
+      onChange({
+        ...step.outputs,
+        agenticQACompleted: true,
+        agenticQAReport: qaReport,
+        lastQASessionId: qaReport.sessionId
+      });
+    }
   };
 
   return (

--- a/components/ui/AgenticFormattingChecker.tsx
+++ b/components/ui/AgenticFormattingChecker.tsx
@@ -32,8 +32,13 @@ export function AgenticFormattingChecker({ workflowId, onComplete }: AgenticForm
   const [copySuccess, setCopySuccess] = useState<Record<string, boolean>>({});
   const [isLoading, setIsLoading] = useState(true);
 
+  const [hasLoadedSession, setHasLoadedSession] = useState(false);
+
   // Load existing QA session on component mount
   useEffect(() => {
+    // Only load once on mount
+    if (hasLoadedSession) return;
+    
     const loadExistingSession = async () => {
       try {
         setIsLoading(true);
@@ -99,11 +104,25 @@ export function AgenticFormattingChecker({ workflowId, onComplete }: AgenticForm
         // Don't show error for missing sessions - this is expected for new workflows
       } finally {
         setIsLoading(false);
+        setHasLoadedSession(true);
       }
     };
     
     loadExistingSession();
-  }, [workflowId, onComplete]);
+  }, [workflowId]); // Remove onComplete from dependencies
+
+  // Call onComplete when session status changes to completed
+  useEffect(() => {
+    if (status === 'completed' && sessionId && onComplete && cleanedArticle) {
+      onComplete({
+        sessionId: sessionId,
+        status: status,
+        checks: checks,
+        cleanedArticle: cleanedArticle,
+        fixesApplied: fixesApplied
+      });
+    }
+  }, [status]); // Only trigger when status changes
 
   // Check type display names
   const checkTypeNames: Record<string, string> = {


### PR DESCRIPTION
- Remove onComplete from useEffect dependencies to prevent circular updates
- Add hasLoadedSession flag to ensure session loads only once on mount
- Add session ID check in parent component to prevent duplicate updates
- Fix jittery UI behavior where 'Loading existing QA session' kept flashing