### PR TITLE
fix: Remove fileSearchTool from o3-deep-research agent - not supported

### DIFF
--- a/app/api/admin/diagnose-outline-generation-live/route.ts
+++ b/app/api/admin/diagnose-outline-generation-live/route.ts
@@ -98,8 +98,8 @@ Create a comprehensive research outline based on the instructions provided.`;
         model: 'o3-deep-research', // Correct model for complex research
         instructions: RESEARCH_AGENT_PROMPT,
         tools: [
-          webSearchTool(),
-          fileSearchTool(['vs_68710d7858ec8191b829a50012da7707'])
+          webSearchTool()
+          // Note: fileSearchTool not supported with o3-deep-research model
         ]
       });
       diagnostics.agentCreation.researchAgent = { 

--- a/lib/services/agenticOutlineService.ts
+++ b/lib/services/agenticOutlineService.ts
@@ -195,8 +195,8 @@ export class AgenticOutlineService {
         model: 'o3-deep-research',
         instructions: RESEARCH_AGENT_PROMPT,
         tools: [
-          webSearchTool(),
-          fileSearchTool(['vs_68710d7858ec8191b829a50012da7707']) // Knowledge base for guidelines
+          webSearchTool()
+          // Note: fileSearchTool not supported with o3-deep-research model
         ]
       });
 
@@ -366,8 +366,8 @@ export class AgenticOutlineService {
         model: 'o3-deep-research',
         instructions: RESEARCH_AGENT_PROMPT,
         tools: [
-          webSearchTool(),
-          fileSearchTool(['vs_68710d7858ec8191b829a50012da7707'])
+          webSearchTool()
+          // Note: fileSearchTool not supported with o3-deep-research model
         ]
       });
 


### PR DESCRIPTION
- Removed fileSearchTool from research agents using o3-deep-research model
- Updated both main service and diagnostic API
- o3-deep-research only supports webSearchTool, not hosted file_search tool

Fixes error: "400 Hosted tool 'file_search' is not supported with o3-deep-research"

🤖 Generated with [Claude Code](https://claude.ai/code)