### PR TITLE
Update AI agent tab labels for clarity

### DIFF
--- a/components/steps/ArticleDraftStepClean.tsx
+++ b/components/steps/ArticleDraftStepClean.tsx
@@ -205,7 +205,7 @@ ${outlineContent || '((((Complete Step 3: Deep Research first to get outline con
                 : 'text-gray-500 hover:text-gray-700 hover:bg-gray-50'
             }`}
           >
-            🤖 AI Agent Beta - Do Not Use
+            🤖 AI Agent Beta
           </button>
         </div>
 

--- a/components/steps/DeepResearchStepClean.tsx
+++ b/components/steps/DeepResearchStepClean.tsx
@@ -90,7 +90,7 @@ export const DeepResearchStepClean = ({ step, workflow, onChange }: DeepResearch
           >
             <div className="flex items-center justify-center space-x-2">
               <Bot className="w-4 h-4" />
-              <span>AI Research (Beta)</span>
+              <span>AI Research (⚠️ BETA - EXPENSIVE)</span>
             </div>
           </button>
         </div>


### PR DESCRIPTION
- Deep Research tab: Add warning that AI Research is BETA and EXPENSIVE
- Article Draft tab: Remove "Do Not Use" text, keeping just "AI Agent Beta"

These changes improve user clarity about the AI agent features' status and costs.

🤖 Generated with [Claude Code](https://claude.ai/code)