### PR TITLE
fix: Prevent auto-navigation after AI agent completion to avoid data …

### DIFF
--- a/app/workflow/[id]/page.tsx
+++ b/app/workflow/[id]/page.tsx
@@ -75,7 +75,7 @@ export default function WorkflowDetail() {
     }, 100);
   };
 
-  const handleStepSave = async (inputs: Record<string, any>, outputs: Record<string, any>) => {
+  const handleStepSave = async (inputs: Record<string, any>, outputs: Record<string, any>, isManualSave: boolean = false) => {
     if (!workflow) return;
 
     try {
@@ -100,9 +100,12 @@ export default function WorkflowDetail() {
       setWorkflow(updatedWorkflow);
       await storage.saveWorkflow(updatedWorkflow);
       
-      // Auto-advance to next step if not at the last step
-      if (activeStep < workflow.steps.length - 1) {
+      // Only auto-advance on manual save (user clicking save button), not on auto-save
+      if (isManualSave && activeStep < workflow.steps.length - 1) {
+        console.log('📍 Auto-advancing to next step after manual save');
         changeActiveStep(activeStep + 1);
+      } else if (!isManualSave) {
+        console.log('💾 Auto-save completed - staying on current step');
       }
     } catch (error) {
       console.error('Error saving step:', error);

--- a/components/StepForm.tsx
+++ b/components/StepForm.tsx
@@ -35,7 +35,7 @@ interface StepFormProps {
   step: WorkflowStep;
   stepIndex: number;
   workflow: GuestPostWorkflow;
-  onSave: (inputs: Record<string, any>, outputs: Record<string, any>) => void;
+  onSave: (inputs: Record<string, any>, outputs: Record<string, any>, isManualSave?: boolean) => void;
   onWorkflowChange?: (workflow: GuestPostWorkflow) => void;
 }
 
@@ -81,7 +81,7 @@ export default function StepForm({ step, stepIndex, workflow, onSave, onWorkflow
     // Set new timer for auto-save after 2 seconds of no changes
     const timer = setTimeout(() => {
       console.log('⏱️ Auto-saving after 2 seconds of inactivity');
-      handleSave();
+      handleSave(false); // Pass false to indicate auto-save, not manual save
     }, 2000);
 
     setAutoSaveTimer(timer);
@@ -96,8 +96,8 @@ export default function StepForm({ step, stepIndex, workflow, onSave, onWorkflow
       if (autoSaveTimer) {
         clearTimeout(autoSaveTimer);
       }
-      // Save immediately
-      handleSave();
+      // Save immediately (but don't navigate - pass false for auto-save)
+      handleSave(false);
     }
   }, [localOutputs.finalArticle, step.id]);
 
@@ -110,10 +110,10 @@ export default function StepForm({ step, stepIndex, workflow, onSave, onWorkflow
     };
   }, [autoSaveTimer]);
 
-  const handleSave = async () => {
-    console.log('🟢 handleSave called:', { localInputs, localOutputs });
+  const handleSave = async (isManualSave: boolean = false) => {
+    console.log('🟢 handleSave called:', { localInputs, localOutputs, isManualSave });
     setIsSaving(true);
-    await onSave(localInputs, localOutputs);
+    await onSave(localInputs, localOutputs, isManualSave);
     setIsSaving(false);
     setLastSaved(new Date());
   };
@@ -211,7 +211,7 @@ export default function StepForm({ step, stepIndex, workflow, onSave, onWorkflow
       <div className="mt-6 pt-4 border-t">
         <div className="flex items-center justify-between">
           <button
-            onClick={handleSave}
+            onClick={() => handleSave(true)}
             disabled={isSaving}
             className="inline-flex items-center px-4 py-2 bg-green-600 text-white text-sm font-medium rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 disabled:opacity-50"
           >


### PR DESCRIPTION
…loss

The issue: When AI agents (article draft, semantic SEO) completed their work, the workflow would auto-advance to the next step immediately, causing data loss because the content wasn't fully saved before navigation.

Root cause: handleStepSave was auto-advancing to next step for ALL saves, including auto-saves triggered by AI completion.

The fix:
- Add isManualSave parameter to distinguish manual saves from auto-saves
- Only auto-advance when user clicks 'Save & Next Step' button (manual save)
- Auto-saves from AI completion no longer trigger navigation
- Polish step immediate save no longer causes navigation
- Added console logs to track save behavior

This ensures AI-generated content is properly saved before any navigation occurs.