### PR TITLE
fix: Add required web_search_preview tool to o3-deep-research API calls

### DIFF
--- a/lib/services/agenticOutlineServiceV2.ts
+++ b/lib/services/agenticOutlineServiceV2.ts
@@ -139,11 +139,15 @@ You must conduct thorough web research before creating the outline. Follow these
 Begin your research now.`;
 
       // Start the background response generation
+      // Note: o3-deep-research model requires at least one tool to be specified
       const response = await this.getClient().responses.create({
         model: 'o3-deep-research',
         input: enhancedPrompt,
         background: true,
         store: true, // Required for background mode
+        tools: [
+          { type: 'web_search_preview' } // Required for o3-deep-research model
+        ]
       });
 
       console.log(`🚀 Background response created with ID: ${response.id}`);


### PR DESCRIPTION
The o3-deep-research model requires at least one tool to be specified in the API call. Added web_search_preview tool to enable the model's web research capabilities.

🤖 Generated with [Claude Code](https://claude.ai/code)