### PR TITLE
feat: Implement ChatGPT's retry fix for agent text responses

### DIFF
--- a/lib/utils/agentUtils.ts
+++ b/lib/utils/agentUtils.ts
@@ -1,0 +1,43 @@
+/**
+ * Utility functions for managing agentic workflows and preventing text-only responses
+ */
+
+/**
+ * Detects when an assistant sends plain text instead of using tools
+ */
+export function assistantSentPlainText(event: any): boolean {
+  return (
+    event.type === 'run_item_stream_event' &&
+    event.name === 'message_output_created' &&
+    !event.item.tool_calls?.length            // => no function call
+  );
+}
+
+/**
+ * Standard retry nudge for agents that output text instead of tools
+ */
+export const RETRY_NUDGE =
+  '🚨 FORMAT INVALID – respond ONLY by calling the required function. ' +
+  'Do NOT output progress updates or explanatory text.';
+
+/**
+ * Semantic SEO specific retry nudge
+ */
+export const SEMANTIC_AUDIT_RETRY_NUDGE =
+  '🚨 FORMAT INVALID – respond ONLY by calling the audit_section function. ' +
+  'Do NOT output progress updates.';
+
+/**
+ * Article writing specific retry nudge  
+ */
+export const ARTICLE_WRITING_RETRY_NUDGE =
+  '🚨 FORMAT INVALID – respond ONLY by calling the write_section function. ' +
+  'Do NOT output progress updates.';
+
+/**
+ * General purpose retry nudge factory
+ */
+export function createRetryNudge(expectedTool: string): string {
+  return `🚨 FORMAT INVALID – respond ONLY by calling the ${expectedTool} function. ` +
+         'Do NOT output progress updates.';
+}


### PR DESCRIPTION
- Add agentUtils.ts with assistantSentPlainText detection
- Implement immediate retry on plain text responses
- Prevent message history pollution
- Add max retry safety guard (3 attempts)
- Use system messages for stronger authority
- Break inner loop for immediate restart via outer while loop

This prevents agents from outputting progress text instead of using tools, solving the "cannot read properties of null" workflow issues.

Applied to semantic audit service as proof-of-concept. Ready to roll out to other agentic services.

🤖 Generated with [Claude Code](https://claude.ai/code)