### PR TITLE
feat: Apply ChatGPT retry fix to article service + add documentation

### DIFF
--- a/lib/utils/agentUtils.ts
+++ b/lib/utils/agentUtils.ts
@@ -35,6 +35,13 @@ export const ARTICLE_WRITING_RETRY_NUDGE =
   'Do NOT output progress updates.';
 
 /**
+ * Article planning specific retry nudge
+ */
+export const ARTICLE_PLANNING_RETRY_NUDGE =
+  '🚨 FORMAT INVALID – respond ONLY by calling the plan_article function. ' +
+  'Do NOT output progress updates.';
+
+/**
  * General purpose retry nudge factory
  */
 export function createRetryNudge(expectedTool: string): string {


### PR DESCRIPTION
- Add comprehensive documentation section to CLAUDE.md for agent retry fix
- Apply ChatGPT fix pattern to agenticArticleService.ts
- Add article-specific retry nudges to agentUtils.ts
- Implement phase-aware retry logic (planning vs writing phases)
- Remove problematic message_output_created handler
- Add immediate text detection with clean restart

This fixes the "cannot read properties of null" issues in article generation by preventing agents from outputting progress text instead of using tools.

🤖 Generated with [Claude Code](https://claude.ai/code)