### PR TITLE
feat: Improve Polish service reliability with phase-aware retry logic

### DIFF
--- a/lib/utils/agentUtils.ts
+++ b/lib/utils/agentUtils.ts
@@ -74,6 +74,21 @@ export const FORMATTING_QA_GENERATE_RETRY_NUDGE =
   'Do NOT output progress updates.';
 
 /**
+ * Polish service specific retry nudges
+ */
+export const POLISH_AFTER_FILESEARCH_RETRY_NUDGE =
+  '🚨 FORMAT INVALID – You just searched the knowledge base. Now respond ONLY by calling the parse_polish_article function. ' +
+  'Do NOT summarize what you found. Do NOT discuss the guidelines. IMMEDIATELY parse the article.';
+
+export const POLISH_PARSE_RETRY_NUDGE =
+  '🚨 FORMAT INVALID – respond ONLY by calling the parse_polish_article function. ' +
+  'Do NOT output progress updates or summaries.';
+
+export const POLISH_SECTION_RETRY_NUDGE =
+  '🚨 FORMAT INVALID – respond ONLY by calling the polish_section function. ' +
+  'Do NOT output progress updates. Continue polishing sections.';
+
+/**
  * General purpose retry nudge factory
  */
 export function createRetryNudge(expectedTool: string): string {


### PR DESCRIPTION
- Add specific retry nudges for Polish service phases (after file_search, parse, section)
- Track file_search as lastSuccessfulTool for proper phase detection
- Enhance prompts to prevent text responses after file_search
- Add stronger tool usage instructions in agent config and tool outputs
- Remove toolChoice: 'required' (incompatible with file_search)

This makes the Polish service more reliable and less prone to outputting text instead of using tools, especially after file_search operations.

🤖 Generated with [Claude Code](https://claude.ai/code)