### PR TITLE
feat: Make AI Agent Beta the first tab in all remaining steps

### DIFF
--- a/components/steps/ContentAuditStepClean.tsx
+++ b/components/steps/ContentAuditStepClean.tsx
@@ -24,7 +24,7 @@ export const ContentAuditStepClean = ({ step, workflow, onChange }: ContentAudit
   });
 
   // Tab system state
-  const [activeTab, setActiveTab] = useState<'chatgpt' | 'builtin' | 'agent'>('chatgpt');
+  const [activeTab, setActiveTab] = useState<'chatgpt' | 'builtin' | 'agent'>('agent');
 
   // Chat state management
   const [conversation, setConversation] = useState<any[]>([]);
@@ -173,6 +173,16 @@ Now I realize this is a lot, so i want your first output to only be an audit of 
       <div className="bg-white border border-gray-200 rounded-xl overflow-hidden">
         <div className="flex border-b border-gray-200">
           <button
+            onClick={() => setActiveTab('agent')}
+            className={`flex-1 px-6 py-4 text-sm font-medium transition-colors ${
+              activeTab === 'agent'
+                ? 'bg-green-50 text-green-700 border-b-2 border-green-500'
+                : 'text-gray-500 hover:text-gray-700 hover:bg-gray-50'
+            }`}
+          >
+            🤖 AI Agent (Auto)
+          </button>
+          <button
             onClick={() => setActiveTab('chatgpt')}
             className={`flex-1 px-6 py-4 text-sm font-medium transition-colors ${
               activeTab === 'chatgpt'
@@ -191,16 +201,6 @@ Now I realize this is a lot, so i want your first output to only be an audit of 
             }`}
           >
             Built-in Chat
-          </button>
-          <button
-            onClick={() => setActiveTab('agent')}
-            className={`flex-1 px-6 py-4 text-sm font-medium transition-colors ${
-              activeTab === 'agent'
-                ? 'bg-green-50 text-green-700 border-b-2 border-green-500'
-                : 'text-gray-500 hover:text-gray-700 hover:bg-gray-50'
-            }`}
-          >
-            🤖 AI Agent (Auto)
           </button>
         </div>
 

--- a/components/steps/FinalPolishStepClean.tsx
+++ b/components/steps/FinalPolishStepClean.tsx
@@ -25,7 +25,7 @@ export const FinalPolishStepClean = ({ step, workflow, onChange }: FinalPolishSt
   });
 
   // Tab system state
-  const [activeTab, setActiveTab] = useState<'chatgpt' | 'builtin' | 'agentic'>('chatgpt');
+  const [activeTab, setActiveTab] = useState<'chatgpt' | 'builtin' | 'agentic'>('agentic');
 
   // Chat state management
   const [conversation, setConversation] = useState<any[]>([]);
@@ -181,6 +181,19 @@ Review one of my project files for my brand guide and the Semantic SEO writing t
       <div className="bg-white border border-gray-200 rounded-xl overflow-hidden">
         <div className="flex border-b border-gray-200">
           <button
+            onClick={() => setActiveTab('agentic')}
+            className={`flex-1 px-6 py-4 text-sm font-medium transition-colors ${
+              activeTab === 'agentic'
+                ? 'bg-purple-50 text-purple-700 border-b-2 border-purple-500'
+                : 'text-gray-500 hover:text-gray-700 hover:bg-gray-50'
+            }`}
+          >
+            <div className="flex items-center justify-center space-x-2">
+              <Sparkles className="w-4 h-4" />
+              <span>Agentic Polish</span>
+            </div>
+          </button>
+          <button
             onClick={() => setActiveTab('chatgpt')}
             className={`flex-1 px-6 py-4 text-sm font-medium transition-colors ${
               activeTab === 'chatgpt'
@@ -199,19 +212,6 @@ Review one of my project files for my brand guide and the Semantic SEO writing t
             }`}
           >
             Built-in Chat
-          </button>
-          <button
-            onClick={() => setActiveTab('agentic')}
-            className={`flex-1 px-6 py-4 text-sm font-medium transition-colors ${
-              activeTab === 'agentic'
-                ? 'bg-purple-50 text-purple-700 border-b-2 border-purple-500'
-                : 'text-gray-500 hover:text-gray-700 hover:bg-gray-50'
-            }`}
-          >
-            <div className="flex items-center justify-center space-x-2">
-              <Sparkles className="w-4 h-4" />
-              <span>Agentic Polish</span>
-            </div>
           </button>
         </div>
 

--- a/components/steps/FormattingQAStepClean.tsx
+++ b/components/steps/FormattingQAStepClean.tsx
@@ -14,7 +14,7 @@ interface FormattingQAStepProps {
 }
 
 export const FormattingQAStepClean = ({ step, workflow, onChange }: FormattingQAStepProps) => {
-  const [activeTab, setActiveTab] = useState<'manual' | 'agentic'>('manual');
+  const [activeTab, setActiveTab] = useState<'manual' | 'agentic'>('agentic');
   
   const articleDraftStep = workflow.steps.find(s => s.id === 'article-draft');
   const googleDocUrl = articleDraftStep?.outputs?.googleDocUrl || '';
@@ -58,17 +58,6 @@ export const FormattingQAStepClean = ({ step, workflow, onChange }: FormattingQA
       {/* Tab Navigation */}
       <div className="flex space-x-1 p-1 bg-gray-100 rounded-lg">
         <button
-          onClick={() => setActiveTab('manual')}
-          className={`flex-1 flex items-center justify-center px-4 py-2 rounded-md text-sm font-medium transition-colors ${
-            activeTab === 'manual'
-              ? 'bg-white text-gray-900 shadow-sm'
-              : 'text-gray-600 hover:text-gray-900'
-          }`}
-        >
-          <CheckSquare className="w-4 h-4 mr-2" />
-          Manual Checklist
-        </button>
-        <button
           onClick={() => setActiveTab('agentic')}
           className={`flex-1 flex items-center justify-center px-4 py-2 rounded-md text-sm font-medium transition-colors ${
             activeTab === 'agentic'
@@ -78,6 +67,17 @@ export const FormattingQAStepClean = ({ step, workflow, onChange }: FormattingQA
         >
           <Bot className="w-4 h-4 mr-2" />
           AI QA Checker
+        </button>
+        <button
+          onClick={() => setActiveTab('manual')}
+          className={`flex-1 flex items-center justify-center px-4 py-2 rounded-md text-sm font-medium transition-colors ${
+            activeTab === 'manual'
+              ? 'bg-white text-gray-900 shadow-sm'
+              : 'text-gray-600 hover:text-gray-900'
+          }`}
+        >
+          <CheckSquare className="w-4 h-4 mr-2" />
+          Manual Checklist
         </button>
       </div>
 


### PR DESCRIPTION
- Changed default active tab to 'agent'/'agentic' in:
  - Content Audit (Semantic SEO) step
  - Final Polish step
  - Formatting QA step
- Reordered tab buttons to show AI agents first
- Built and tested successfully