### PR TITLE
feat: Add cost protection and update AI Research tab label

### DIFF
--- a/components/steps/DeepResearchStepClean.tsx
+++ b/components/steps/DeepResearchStepClean.tsx
@@ -91,7 +91,7 @@ export const DeepResearchStepClean = ({ step, workflow, onChange }: DeepResearch
           >
             <div className="flex items-center justify-center space-x-2">
               <Bot className="w-4 h-4" />
-              <span>AI Research (⚠️ DO NOT USE - EXPENSIVE)</span>
+              <span>AI Agent (Use ChatGPT first - $$$)</span>
             </div>
           </button>
         </div>

--- a/components/ui/CostConfirmationDialog.tsx
+++ b/components/ui/CostConfirmationDialog.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import React from 'react';
+import { AlertTriangle, DollarSign, X } from 'lucide-react';
+
+interface CostConfirmationDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  title: string;
+  description: string;
+  estimatedCost?: string;
+  warningMessage?: string;
+}
+
+export const CostConfirmationDialog = ({
+  isOpen,
+  onClose,
+  onConfirm,
+  title,
+  description,
+  estimatedCost,
+  warningMessage
+}: CostConfirmationDialogProps) => {
+  if (!isOpen) return null;
+
+  const handleConfirm = () => {
+    onConfirm();
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg p-6 max-w-md w-full mx-4 shadow-xl">
+        {/* Header */}
+        <div className="flex items-start justify-between mb-4">
+          <div className="flex items-center space-x-3">
+            <div className="bg-yellow-100 p-2 rounded-full">
+              <DollarSign className="w-6 h-6 text-yellow-600" />
+            </div>
+            <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 transition-colors"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="space-y-4">
+          <p className="text-gray-600">{description}</p>
+
+          {estimatedCost && (
+            <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">
+              <div className="flex items-center space-x-2">
+                <DollarSign className="w-4 h-4 text-blue-600" />
+                <span className="text-sm font-medium text-blue-900">
+                  Estimated Cost: {estimatedCost}
+                </span>
+              </div>
+            </div>
+          )}
+
+          {warningMessage && (
+            <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-3">
+              <div className="flex items-start space-x-2">
+                <AlertTriangle className="w-4 h-4 text-yellow-600 mt-0.5" />
+                <span className="text-sm text-yellow-800">{warningMessage}</span>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Actions */}
+        <div className="flex justify-end space-x-3 mt-6">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleConfirm}
+            className="px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors flex items-center space-x-2"
+          >
+            <span>Confirm & Start</span>
+            <DollarSign className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
Features:
- Updated Deep Research tab label to 'AI Agent (Use ChatGPT first - 9948$)'
- Added CostConfirmationDialog component for expensive operations
- Implemented double-click protection on AI agent start buttons
- Added cost confirmation dialogs for:
  - Article Generator (/bin/bash.50 - .00)
  - Semantic SEO Auditor (/bin/bash.30 - .00)
- Button disabling during operation prevents multiple API calls
- Clear cost estimates help users make informed decisions

Protection mechanisms:
- Immediate button disabling on click
- Confirmation dialogs with cost estimates
- Error handling re-enables buttons
- Clear warning messages about expenses