### PR TITLE
fix: Handle both 'text' and 'output_text' content types in V2 extraction

### DIFF
--- a/lib/services/agenticArticleV2Service.ts
+++ b/lib/services/agenticArticleV2Service.ts
@@ -164,7 +164,10 @@ export class AgenticArticleV2Service {
           planningResponse = lastAssistant.content;
         } else if (Array.isArray(lastAssistant.content)) {
           planningResponse = lastAssistant.content
-            .filter((item: any) => item.type === 'text')
+            .filter((item: any) => 
+              // Accept both shapes the SDK emits
+              item.type === 'text' || item.type === 'output_text'
+            )
             .map((item: any) => item.text || '')
             .join('');
         }
@@ -223,7 +226,10 @@ export class AgenticArticleV2Service {
           titleIntroResponse = lastAssistant.content;
         } else if (Array.isArray(lastAssistant.content)) {
           titleIntroResponse = lastAssistant.content
-            .filter((item: any) => item.type === 'text')
+            .filter((item: any) => 
+              // Accept both shapes the SDK emits
+              item.type === 'text' || item.type === 'output_text'
+            )
             .map((item: any) => item.text || '')
             .join('');
         }
@@ -300,7 +306,10 @@ export class AgenticArticleV2Service {
             sectionResponse = lastAssistant.content;
           } else if (Array.isArray(lastAssistant.content)) {
             sectionResponse = lastAssistant.content
-              .filter((item: any) => item.type === 'text')
+              .filter((item: any) => 
+                // Accept both shapes the SDK emits
+                item.type === 'text' || item.type === 'output_text'
+              )
               .map((item: any) => item.text || '')
               .join('');
           }


### PR DESCRIPTION
The "No planning response extracted" error was caused by filtering for content type === 'text' when the SDK actually uses type === 'output_text' for streamed runs.

Changes:
- Update content extraction to accept both 'text' and 'output_text' types
- Apply fix to all three phases (planning, title/intro, sections)
- The SDK uses 'output_text' for streamed runs and 'text' for non-streamed

This ensures we correctly extract assistant responses regardless of run mode.

🤖 Generated with [Claude Code](https://claude.ai/code)