### PR TITLE
fix: Switch ArticleEndCritic model from o2-mini to gpt-4.1-nano

### DIFF
--- a/lib/agents/articleWriterV2.ts
+++ b/lib/agents/articleWriterV2.ts
@@ -17,7 +17,7 @@ export const writerAgentV2 = new Agent({
 // Factory function to create ArticleEndCritic with dynamic outline
 export const createArticleEndCritic = (outline: string) => new Agent({
   name: 'ArticleEndCritic',
-  model: 'o2-mini-2025-06-10',
+  model: 'gpt-4.1-nano',
   instructions: `You are an END-OF-ARTICLE detector.
 
 Here is the article outline:


### PR DESCRIPTION
The o2-mini model was causing errors. Switching to gpt-4.1-nano which is a valid model for the judge agent.

🤖 Generated with [Claude Code](https://claude.ai/code)