### PR TITLE
fix: Set ChatGPT tab as default and fix content extraction in V2 sema…

### DIFF
--- a/components/steps/ContentAuditStepClean.tsx
+++ b/components/steps/ContentAuditStepClean.tsx
@@ -25,7 +25,7 @@ export const ContentAuditStepClean = ({ step, workflow, onChange }: ContentAudit
   });
 
   // Tab system state
-  const [activeTab, setActiveTab] = useState<'chatgpt' | 'builtin' | 'agent' | 'agentv2'>('agentv2');
+  const [activeTab, setActiveTab] = useState<'chatgpt' | 'builtin' | 'agent' | 'agentv2'>('chatgpt');
 
   // Chat state management
   const [conversation, setConversation] = useState<any[]>([]);


### PR DESCRIPTION
…ntic audit

- Change default tab from 'agentv2' to 'chatgpt' in ContentAuditStepClean
- Fix TypeError by properly extracting text content from assistant messages
- Add extractTextContent helper method to handle string/array content formats
- Follow same content extraction pattern as V2 article service

🤖 Generated with [Claude Code](https://claude.ai/code)