### PR TITLE
fix: Complete separation of intermediary and final article content in…

### DIFF
--- a/lib/services/agenticSemanticAuditV2Service.ts
+++ b/lib/services/agenticSemanticAuditV2Service.ts
@@ -322,11 +322,12 @@ In cases where a section has many subsections, output just the subsection. While
       // Update workflow with clean audited article
       await this.updateWorkflowWithAuditedArticle(session.workflowId, cleanSuggestedArticle);
       
-      // Send completion event with clean article
+      // Send completion event with both intermediary and final content
       auditV2SSEPush(sessionId, { 
         type: 'complete',
         status: 'completed',
-        auditedArticle: cleanSuggestedArticle,  // Send parsed clean article
+        intermediaryContent: accumulatedAuditContent,  // Full audit with markdown headers
+        finalArticle: cleanSuggestedArticle,  // Parsed clean article only
         sectionsCompleted,
         message: 'V2 semantic audit completed successfully!'
       });


### PR DESCRIPTION
… V2 semantic audit

- Add missing showIntermediaryView state variable to AgenticSemanticAuditorV2
- Enable proper toggling between analysis view (markdown with headers) and final article view
- Ensure intermediary content streams during processing without affecting final article
- Final article only updates at completion with parsed clean content
- Maintain separation to ensure final article persists on page refresh

This completes the architectural separation requested where streaming markdown content is kept separate from the final parsed article that gets saved to the database.