### PR TITLE
docs: Major documentation refactor - split CLAUDE.md into focused guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,181 +1,61 @@
-# Guest Post Workflow v1.0.0 🚀
+# Guest Post Workflow
 
-A comprehensive 16-step guest post workflow management system built for OutreachLabs.
-
-## 📋 Overview
-
-This Next.js application provides a complete workflow management system for guest post creation, from site selection to final publication. It includes multi-user support, client management, and integrates with OpenAI GPT projects for content creation.
-
-## ✨ Key Features
-
-- **16-Step Workflow System** - Complete guest post creation process
-- **Multi-User Support** - PostgreSQL database with role-based access
-- **Client Management** - Track clients and their target pages
-- **Workflow Persistence** - All step data saves automatically
-- **Multi-Account GPT Integration** - Support for 3 OpenAI accounts
-- **Admin Dashboard** - User management and analytics
-
-## 🏗️ Architecture
-
-### Tech Stack
-- **Frontend**: Next.js 15.3.4 with React 19
-- **Database**: PostgreSQL with Drizzle ORM
-- **Authentication**: Custom auth with bcryptjs
-- **Styling**: Tailwind CSS
-- **Deployment**: Coolify v4
-
-### Database Schema
-- Users (authentication & roles)
-- Clients (customer information)
-- Workflows (16-step process data as JSON)
-- Target Pages (client website targets)
+A 16-step workflow management system for creating and publishing guest posts.
 
 ## 🚀 Quick Start
 
-### Prerequisites
-- Node.js 18+
-- PostgreSQL database
-- Environment variables configured
+**Prerequisites**: Node.js 18+, PostgreSQL
 
-### Installation
-
-1. **Clone the repository**
-   ```bash
-   git clone https://github.com/ajaypag/guest-post-workflow.git
-   cd guest-post-workflow
-   ```
-
-2. **Install dependencies**
-   ```bash
-   npm install
-   ```
-
-3. **Set up environment variables**
-   ```env
-   DATABASE_URL=postgresql://user:password@host:port/database?sslmode=disable
-   NEXTAUTH_SECRET=your-secret-key
-   NEXTAUTH_URL=http://localhost:3000
-   ```
-
-4. **Run development server**
-   ```bash
-   npm run dev
-   ```
-
-5. **Open browser**
-   Visit [http://localhost:3000](http://localhost:3000)
-
-### First Time Setup
-- Default admin: `admin@example.com` / `admin123`
-- Database initializes automatically on first run
-- Create clients and start your first workflow
-
-## 📖 Usage
-
-### The 16-Step Workflow Process
-
-1. **Domain Selection** - Choose target publication site
-2. **Site Qualification** - Research and prepare
-3. **Topic Generation** - Find ranking opportunities
-4. **Outline Creation** - Deep research with GPT-o3
-5. **Article Draft** - Write with GPT-o3 Advanced Reasoning
-6. **Semantic SEO** - Optimize content section by section
-7. **Polish & Finalize** - Brand alignment review
-8. **Formatting & QA** - Manual review and citations
-9. **Internal Links** - Add guest site links
-10. **Tier 2 Links** - Link to other guest posts
-11. **Client Mention** - Add for AI overviews
-12. **Client Link** - Natural link insertion
-13. **Images** - Generate visual content
-14. **Link Requests** - Internal link opportunities
-15. **URL Suggestion** - Recommend post URL
-16. **Email Template** - Publisher communication
-
-### Client Management
-- Add clients with website and description
-- Manage target pages for each client
-- Track page status (active/inactive/completed)
-- Assign users to clients
-
-### OpenAI Integration
-The system supports three OpenAI accounts:
-- **info@onlyoutreach.com** (primary)
-- **ajay@pitchpanda.com**
-- **ajay@linkio.com**
-
-Users select the appropriate GPT link based on their login.
-
-## 🔧 Development
-
-### Build & Test
 ```bash
-# Development
+# Clone and install
+git clone https://github.com/ajaypag/guest-post-workflow.git
+cd guest-post-workflow
+npm install
+
+# Configure environment
+cp .env.example .env
+# Edit .env with your database credentials
+
+# Run locally
 npm run dev
-
-# Production build
-npm run build
-
-# Start production server
-npm start
-
-# Lint code
-npm run lint
+# Open http://localhost:3000
 ```
 
-### Database Operations
+**Default login**: `admin@example.com` / `admin123`
+
+## 📋 What It Does
+
+- **16-step workflow** from topic research to email templates
+- **Multi-user** with PostgreSQL database
+- **Client management** with target pages tracking
+- **OpenAI integration** for content generation
+- **Auto-save** at every step
+
+## 📖 Documentation
+
+| Topic | Description |
+|-------|-------------|
+| [Local Development](docs/setup/LOCAL_DEV.md) | Full setup guide, troubleshooting |
+| [Coolify Deployment](docs/setup/COOLIFY_DEPLOY.md) | Production deployment steps |
+| [Building Agents](docs/agents/BUILDING_BLOCKS.md) | Create new AI agents |
+| [Database Rules](docs/db/SCHEMA_RULES.md) | Schema patterns, VARCHAR sizes |
+| [Diagnostics](docs/admin/DIAGNOSTICS.md) | Debug production issues |
+| [Developer Guide](docs/DEVELOPER_GUIDE.md) | All technical details |
+
+## 🛠️ Common Tasks
+
 ```bash
-# Generate migrations
-npm run db:generate
-
-# View database
-npm run db:studio
+npm run dev          # Start development server
+npm run build        # Production build
+npm run db:studio    # Browse database
+npm run lint         # Check code style
 ```
 
-### Diagnostic Tools
-- `/database-checker` - System health analysis
-- `/api/workflows/[id]/validate` - Workflow validation
-- `/api/check-table-structure` - Schema verification
+## 🔍 Troubleshooting
 
-## 🚀 Deployment
-
-### Coolify Deployment
-1. Connect GitHub repository to Coolify
-2. Set environment variables in Coolify dashboard
-3. Configure PostgreSQL database
-4. Deploy as Next.js application
-
-### Environment Variables
-```env
-DATABASE_URL=postgresql://user:password@internal-host:5432/database?sslmode=disable
-NEXTAUTH_SECRET=production-secret-key
-NEXTAUTH_URL=https://your-domain.com
-```
-
-## 📝 Version History
-
-### v1.0.0 (2025-01-02) - Production Release
-- ✅ Complete workflow system with data persistence
-- ✅ Multi-user PostgreSQL integration
-- ✅ Client and target page management
-- ✅ Multi-account OpenAI support
-- ✅ All major bugs fixed and tested
-
-## 📚 Documentation
-
-- **CLAUDE.md** - Technical documentation for AI reference
-- **CHANGELOG.md** - Detailed version history
-- **API Documentation** - Available endpoints and usage
-
-## 🐛 Known Issues
-
-None in v1.0.0 - this is a stable production release.
-
-## 🤝 Support
-
-For issues or questions:
-1. Check the diagnostic tools at `/database-checker`
-2. Review logs for error details
-3. Verify environment variables are correct
+1. **Database errors**: Visit `/database-checker`
+2. **Workflow issues**: Check `/api/workflows/[id]/validate`
+3. **Login problems**: Verify `DATABASE_URL` in `.env`
 
 ## 📄 License
 
@@ -183,4 +63,4 @@ Private - OutreachLabs Internal Use
 
 ---
 
-**Built with ❤️ for OutreachLabs**
+**Need help?** Check [docs/](docs/) or search the codebase for examples.

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -1,0 +1,135 @@
+# Developer Guide
+
+Comprehensive technical documentation for the Guest Post Workflow system.
+
+## 📚 Documentation Map
+
+### Getting Started
+- [Local Development Setup](setup/LOCAL_DEV.md) - Get running in < 10 minutes
+- [Coolify Deployment](setup/COOLIFY_DEPLOY.md) - Production deployment guide
+
+### Building Features
+- [Agent Building Blocks](agents/BUILDING_BLOCKS.md) - Create AI agents
+- [Retry Pattern](agents/RETRY_PATTERN.md) - Handle agent text responses
+- [V2 Pattern](agents/V2_PATTERN.md) - LLM orchestration approach
+
+### Database & Infrastructure  
+- [Schema Rules](db/SCHEMA_RULES.md) - VARCHAR sizes, TEXT usage
+- [Migration Checklist](migrations/CHECKLIST.md) - Adding new tables
+
+### Debugging & Operations
+- [Diagnostics Guide](admin/DIAGNOSTICS.md) - Debug production issues
+- [Admin UI Requirements](admin/UI_REQUIREMENTS.md) - Required admin pages
+
+### Architecture Decisions
+- [Component Clean Pattern](architecture/COMPONENT_PATTERN.md) - Step component architecture
+- [Session Management](architecture/SESSIONS.md) - Agent session patterns
+
+## 🏗️ System Overview
+
+### Tech Stack
+- **Frontend**: Next.js 15.3.4, React 19, Tailwind CSS
+- **Backend**: Next.js API routes, PostgreSQL, Drizzle ORM
+- **AI**: OpenAI Agents SDK, o3-2025-04-16 model
+- **Deployment**: Coolify v4, Docker
+
+### Key Services
+```
+/lib/services/
+├── agenticArticleService.ts      # V1 article generation
+├── agenticArticleV2Service.ts    # V2 LLM orchestration
+├── agenticSemanticAuditService.ts # SEO optimization
+└── workflowService.ts            # Core workflow CRUD
+```
+
+### Database Architecture
+- **Users**: Authentication and roles
+- **Workflows**: JSON storage for flexibility
+- **Clients**: Customer management
+- **Agent Sessions**: Agentic feature tracking
+
+## 🔑 Critical Knowledge
+
+### Step Components Have Two Versions
+Due to technical debt, check which version is active:
+```typescript
+// components/StepForm.tsx shows real mapping
+const stepForms = {
+  'article-draft': ArticleDraftStepClean,  // NOT ArticleDraftStep
+  'content-audit': ContentAuditStepClean,  // NOT ContentAuditStep
+  // ...
+};
+```
+
+### Always Use TEXT for AI Content
+```sql
+-- ❌ WRONG - Will fail silently
+description VARCHAR(100)
+
+-- ✅ CORRECT - No size limits
+description TEXT
+```
+
+### V2 is the Future
+V2 pattern (LLM orchestration) produces better results than V1 (code orchestration).
+
+## 📋 Common Tasks
+
+### Add New Agent Feature
+1. Read [Building Blocks](agents/BUILDING_BLOCKS.md)
+2. Create service in `/lib/services/`
+3. Use TEXT columns in database
+4. Add admin diagnostics
+5. Implement SSE streaming
+
+### Debug Production Issue
+1. Check `/admin/diagnostics`
+2. Look for VARCHAR limits
+3. Verify table structure
+4. Test with real data
+
+### Update Step Component
+1. Find which version is used (`grep -r "ComponentName"`)
+2. Check `StepForm.tsx` mapping
+3. Edit the Clean version
+4. Test auto-save works
+
+## 🚨 Before You Start
+
+### Environment Setup
+```env
+DATABASE_URL=postgresql://...
+NEXTAUTH_SECRET=...
+OPENAI_API_KEY=sk-...
+```
+
+### Required Tools
+- Node.js 18+
+- PostgreSQL
+- Git
+- VS Code (recommended)
+
+### Useful Commands
+```bash
+npm run dev          # Start development
+npm run db:studio    # Browse database
+npm run build        # Test production build
+npm run lint         # Check code style
+```
+
+## 📞 Getting Help
+
+1. **Search codebase** for examples
+2. **Check diagnostics** at `/admin/*`
+3. **Read error logs** carefully
+4. **Test locally** before deploying
+
+## 🔗 Quick Links
+
+- [Original CLAUDE.md](archive/DEVELOPER_GUIDE_ORIGINAL.md) - Full historical context
+- GitHub: https://github.com/ajaypag/guest-post-workflow
+- Production: Deployed on Coolify
+
+---
+
+**Remember**: This is production software serving real users. Test thoroughly!

--- a/docs/admin/DIAGNOSTICS.md
+++ b/docs/admin/DIAGNOSTICS.md
@@ -1,0 +1,160 @@
+# Production Diagnostics Guide
+
+> **Why**: Debug vague database errors in minutes, not hours  
+> **Use when**: Agent features fail with unclear errors  
+> **Outcome**: Specific root cause and fix instructions
+
+## Diagnostic Workflow (10 min total)
+
+### Phase 1: Structure Analysis (2 min)
+```bash
+# Visit comprehensive diagnostics
+/admin/diagnostics
+
+# Look for:
+- Missing columns
+- Schema mismatches  
+- JSON vs table storage conflicts
+```
+
+### Phase 2: Column Sizes (2 min)
+```bash
+# Check VARCHAR limits
+/admin/varchar-limits
+
+# Auto-fix small columns
+Click "Fix Column Sizes"
+```
+
+### Phase 3: Error Details (2 min)
+```bash
+# Test with real data
+/admin/test-database-inserts
+
+# Get PostgreSQL error codes
+# Not just "database error"
+```
+
+### Phase 4: Migration Status (2 min)
+```bash
+# Verify tables exist
+/admin/database-migration
+
+# Run missing migrations
+Click "Create Tables"
+```
+
+## Common Issues & Quick Fixes
+
+### "Column does not exist"
+**Cause**: Code expects separate table, data is in JSON  
+**Fix**: Update queries to read from `workflows.content`
+```typescript
+// Wrong
+const steps = await db.query.workflow_steps.findMany();
+
+// Right  
+const workflow = await db.query.workflows.findFirst();
+const steps = workflow.content?.steps || [];
+```
+
+### "Failed query: insert"
+**Cause**: VARCHAR too small for AI content  
+**Fix**: Visit `/admin/varchar-limits` → Auto-fix
+```sql
+ALTER TABLE your_table ALTER COLUMN description TYPE TEXT;
+```
+
+### "Invalid input syntax for integer"
+**Cause**: Decimal sent to integer column  
+**Fix**: Round numbers before insert
+```typescript
+confidenceScore: Math.round(score) // 8.5 → 9
+```
+
+### "Null constraint violation"  
+**Cause**: NULL sent to NOT NULL column  
+**Fix**: Use empty string default
+```typescript
+errorMessage: error?.message || '' // Never null
+```
+
+## Admin Pages Reference
+
+| Page | Purpose | When to Use |
+|------|---------|-------------|
+| `/admin/diagnostics` | Full system analysis | First stop for any issue |
+| `/admin/varchar-limits` | Column size checker | "Failed insert" errors |
+| `/admin/database-migration` | Table management | Missing table errors |
+| `/admin/fix-[feature]` | Feature-specific tools | Feature not working |
+| `/database-checker` | Public health check | User-reported issues |
+
+## Creating Diagnostic Pages
+
+Every agentic feature needs:
+
+1. **Migration page section**
+```typescript
+// In /admin/database-migration
+<FeatureMigration 
+  name="Your Feature"
+  checkEndpoint="/api/admin/check-your-feature"
+  migrateEndpoint="/api/admin/migrate-your-feature"
+/>
+```
+
+2. **Feature diagnostic page**
+```typescript
+// /admin/fix-your-feature
+- Table existence check
+- Column size verification  
+- Test data insertion
+- Auto-fix buttons
+```
+
+3. **API endpoints**
+```typescript
+// Required endpoints
+GET  /api/admin/check-your-feature
+POST /api/admin/migrate-your-feature  
+POST /api/admin/fix-your-feature-columns
+```
+
+## PostgreSQL Error Codes
+
+| Code | Meaning | Common Fix |
+|------|---------|------------|
+| 23502 | NOT NULL violation | Use empty string |
+| 22001 | String too long | Increase VARCHAR/use TEXT |
+| 42703 | Column not found | Check actual schema |
+| 22P02 | Invalid text for type | Type conversion needed |
+
+## Emergency Queries
+
+```sql
+-- See actual table structure
+\d table_name
+
+-- Check column sizes
+SELECT column_name, data_type, character_maximum_length
+FROM information_schema.columns
+WHERE table_name = 'your_table';
+
+-- Recent errors
+SELECT * FROM pg_stat_activity 
+WHERE state = 'idle in transaction';
+```
+
+## Prevention Checklist
+
+- [ ] Always use TEXT for AI content
+- [ ] Create admin UI for new features
+- [ ] Test with real AI output
+- [ ] Capture PostgreSQL errors
+- [ ] Document column purposes
+
+## Next Steps
+
+- Implement diagnostics BEFORE issues arise
+- Monitor `/admin/diagnostics` weekly
+- Update this guide with new patterns

--- a/docs/agents/BUILDING_BLOCKS.md
+++ b/docs/agents/BUILDING_BLOCKS.md
@@ -1,0 +1,192 @@
+# Building AI Agents
+
+> **Why**: Create robust, production-ready AI agents for automation  
+> **Use when**: Adding new agentic features to the workflow  
+> **Outcome**: Working agent with proper error handling and streaming
+
+## Agent Service Pattern
+
+### 1. Basic Structure
+
+```typescript
+// lib/services/agenticYourFeatureService.ts
+export class AgenticYourFeatureService {
+  private openaiProvider: OpenAIProvider;
+  
+  constructor() {
+    this.openaiProvider = new OpenAIProvider({
+      apiKey: process.env.OPENAI_API_KEY
+    });
+  }
+  
+  async startSession(workflowId: string, inputs: any): Promise<string> {
+    // Create session in database
+    // Return sessionId
+  }
+  
+  async performTask(sessionId: string): Promise<void> {
+    // Main agent logic with SSE streaming
+  }
+}
+```
+
+### 2. Agent Configuration
+
+```typescript
+const agent = new Agent({
+  name: 'YourAgentName',
+  instructions: `
+    You are an expert at [specific task].
+    This is an AUTOMATED WORKFLOW - continue until completion without asking for permission.
+    [Specific output requirements]
+  `,
+  model: 'o3-2025-04-16', // Best for complex reasoning
+  tools: [fileSearch, customTool]
+});
+```
+
+### 3. Database Schema
+
+Always use TEXT for AI content:
+```sql
+CREATE TABLE your_agent_sessions (
+  id UUID PRIMARY KEY,
+  workflow_id UUID NOT NULL,
+  status VARCHAR(50) NOT NULL,
+  inputs TEXT,           -- NOT VARCHAR
+  outputs TEXT,          -- NOT VARCHAR  
+  error_message TEXT,    -- NOT VARCHAR
+  session_metadata JSONB
+);
+```
+
+## Tool Implementation
+
+### Zod Schema Pattern
+```typescript
+import { z } from 'zod';
+import { tool } from 'ai-agents';
+
+const toolSchema = z.object({
+  section_title: z.string().describe('Section title'),
+  content: z.string().describe('Section content'),
+  is_last: z.boolean().describe('Is this the final section?')
+});
+
+const writeSectionTool = tool({
+  name: "write_section",
+  description: "Write a content section",
+  parameters: toolSchema,
+  execute: async (args) => {
+    // 1. Validate inputs
+    // 2. Save to database
+    // 3. Send SSE update
+    // 4. Return continuation signal
+    return `Section "${args.section_title}" saved. ${args.is_last ? 'COMPLETE' : 'Continue'}`;
+  }
+});
+```
+
+## Real-Time Streaming
+
+### SSE Connection Management
+```typescript
+// lib/streaming/connections.ts
+const activeStreams = new Map<string, any>();
+
+export function addSSEConnection(sessionId: string, res: any) {
+  activeStreams.set(sessionId, res);
+}
+
+export function sseUpdate(sessionId: string, data: any) {
+  const stream = activeStreams.get(sessionId);
+  if (stream) {
+    stream.write(`data: ${JSON.stringify(data)}\n\n`);
+  }
+}
+```
+
+### API Endpoints
+```typescript
+// POST - Start generation
+export async function POST(req: Request, { params }: { params: { id: string } }) {
+  const { inputs } = await req.json();
+  const sessionId = await agentService.startSession(params.id, inputs);
+  return Response.json({ sessionId });
+}
+
+// GET - Stream results
+export async function GET(req: Request, { params }: { params: { id: string } }) {
+  const { searchParams } = new URL(req.url);
+  const sessionId = searchParams.get('sessionId');
+  
+  const res = new Response(null, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+    },
+  });
+  
+  addSSEConnection(sessionId, res);
+  agentService.performTask(sessionId); // Don't await
+  
+  return res;
+}
+```
+
+## Common Patterns
+
+### Conversation Loop
+```typescript
+let conversationActive = true;
+const messages = [{ role: 'user', content: initialPrompt }];
+
+while (conversationActive) {
+  const result = await runner.run(agent, messages, { stream: true });
+  
+  for await (const event of result.toStream()) {
+    // Handle tool calls
+    // Update messages array
+    // Check completion
+  }
+  
+  // Safety limits
+  if (messages.length > 100) {
+    conversationActive = false;
+  }
+}
+```
+
+### Error Handling
+```typescript
+try {
+  await performTask(sessionId);
+} catch (error) {
+  await updateSession(sessionId, { 
+    status: 'failed',
+    errorMessage: error.message 
+  });
+  sseUpdate(sessionId, { type: 'error', message: error.message });
+}
+```
+
+## Testing Checklist
+
+- [ ] Agent completes full workflow
+- [ ] Handles errors gracefully  
+- [ ] SSE streaming works
+- [ ] Database saves correctly
+- [ ] Safety limits prevent loops
+
+## Next Steps
+
+- See [Retry Pattern](RETRY_PATTERN.md) for handling text responses
+- Check [V2 Pattern](V2_PATTERN.md) for simpler LLM orchestration
+- Read [Database Rules](../db/SCHEMA_RULES.md) before creating tables
+
+## Reference Implementations
+
+- Article Generation: `/lib/services/agenticArticleService.ts`
+- Semantic Audit: `/lib/services/agenticSemanticAuditService.ts`
+- V2 Article: `/lib/services/agenticArticleV2Service.ts`

--- a/docs/agents/RETRY_PATTERN.md
+++ b/docs/agents/RETRY_PATTERN.md
@@ -1,0 +1,130 @@
+# Agent Text Response Retry Pattern
+
+> **Why**: Agents sometimes output text instead of using required tools  
+> **Use when**: Building agents that must use tools, not explanatory text  
+> **Outcome**: Agents reliably use tools without message pollution
+
+## The Problem
+
+OpenAI agents may output progress updates instead of calling tools:
+```
+"I'll analyze the content now..."  # ❌ Bad - should use tool
+"Let me write the next section..." # ❌ Bad - should use tool
+```
+
+This causes:
+- "Cannot read properties of null" errors
+- Workflows stuck waiting for tools
+- Polluted conversation history
+
+## The Solution
+
+### 1. Create Agent Utils
+```typescript
+// lib/utils/agentUtils.ts
+export function assistantSentPlainText(event: any): boolean {
+  return (
+    event.type === 'run_item_stream_event' &&
+    event.name === 'message_output_created' &&
+    !event.item.tool_calls?.length
+  );
+}
+
+export const SEMANTIC_AUDIT_RETRY_NUDGE =
+  '🚨 FORMAT INVALID – respond ONLY by calling the audit_section function. ' +
+  'Do NOT output progress updates.';
+
+export function createRetryNudge(expectedTool: string): string {
+  return `🚨 FORMAT INVALID – respond ONLY by calling the ${expectedTool} function. ` +
+         'Do NOT output progress updates.';
+}
+```
+
+### 2. Apply to Your Service
+
+```typescript
+import { assistantSentPlainText, createRetryNudge } from '@/lib/utils/agentUtils';
+
+// Add retry tracking
+let retries = 0;
+const MAX_RETRIES = 3;
+const RETRY_NUDGE = createRetryNudge('your_tool_name');
+
+while (conversationActive) {
+  const result = await runner.run(agent, messages, { stream: true });
+  
+  for await (const event of result.toStream()) {
+    // ✨ Immediate detection and retry
+    if (assistantSentPlainText(event)) {
+      messages.push({ role: 'system', content: RETRY_NUDGE });
+      retries += 1;
+      if (retries > MAX_RETRIES) {
+        throw new Error('Agent not using tools after 3 attempts');
+      }
+      break; // Exit loop, outer while() will retry
+    }
+    
+    // Handle tool calls normally
+    if (event.name === 'tool_called') {
+      retries = 0; // Reset on success
+      // Process tool call...
+    }
+  }
+}
+```
+
+## Key Benefits
+
+1. **No History Pollution**: Bad messages never saved
+2. **Immediate Retry**: `break` triggers new attempt
+3. **System Authority**: System messages carry more weight
+4. **Safety Limit**: Max 3 retries prevents loops
+
+## Implementation Checklist
+
+- [ ] Import `agentUtils`
+- [ ] Add retry variables
+- [ ] Add detection at top of stream loop
+- [ ] Remove old text handlers
+- [ ] Reset retries on tool success
+- [ ] Test retry behavior
+
+## Common Mistakes
+
+### ❌ Wrong: Recording Text Messages
+```typescript
+if (!messageItem.tool_calls?.length) {
+  messages.push({
+    role: 'assistant',
+    content: messageItem.content  // Pollutes history
+  });
+}
+```
+
+### ✅ Right: Immediate Retry
+```typescript
+if (assistantSentPlainText(event)) {
+  messages.push({ role: 'system', content: RETRY_NUDGE });
+  break; // Don't record, just retry
+}
+```
+
+## Testing Strategy
+
+1. **Normal flow**: Complete without retries
+2. **Single retry**: Recovers from one text response
+3. **Multiple retries**: Handles repeated failures
+4. **Max retries**: Fails gracefully after 3 attempts
+
+## Services Using This Pattern
+
+- ✅ `agenticSemanticAuditService.ts`
+- ✅ `agenticArticleService.ts`
+- 🔄 `agenticFormattingQAService.ts`
+- 🔄 `agenticFinalPolishService.ts`
+
+## Next Steps
+
+- Apply to all agent services
+- Monitor retry metrics
+- Adjust nudge messages per service

--- a/docs/agents/V2_PATTERN.md
+++ b/docs/agents/V2_PATTERN.md
@@ -1,0 +1,145 @@
+# V2 LLM Orchestration Pattern
+
+> **Why**: Better quality through natural conversation flow  
+> **Use when**: Building new agent features or refactoring V1  
+> **Outcome**: Superior results with simpler code
+
+## Core Concept
+
+Let the LLM drive the process through conversation, not complex code orchestration.
+
+## Implementation Pattern
+
+### 1. Single Agent, Empty Instructions
+```typescript
+export const writerAgentV2 = new Agent({
+  name: 'ArticleWriterV2',
+  instructions: '', // CRITICAL: Empty - guidance from prompts
+  model: 'o3-2025-04-16',
+  tools: [fileSearch], // Minimal tools
+});
+```
+
+### 2. Database-Driven Prompts
+Store prompts in workflow step fields, not code:
+```typescript
+const PLANNING_PROMPT = workflowStep.inputs.planningPrompt;
+const TITLE_INTRO_PROMPT = workflowStep.inputs.titleIntroPrompt;
+const LOOPING_PROMPT = workflowStep.inputs.loopingPrompt;
+```
+
+### 3. Natural Progression
+```typescript
+// Phase 1: Planning
+let conversationHistory = [
+  { role: 'user', content: `${PLANNING_PROMPT}\n\n${outline}` }
+];
+
+// Phase 2: Title/Intro  
+conversationHistory.push({ 
+  { role: 'user', content: TITLE_INTRO_PROMPT }
+});
+
+// Phase 3: Loop sections
+while (!complete) {
+  conversationHistory.push(
+    { role: 'user', content: LOOPING_PROMPT }
+  );
+}
+```
+
+## Critical Rules
+
+### ❌ Never Break Message-Reasoning Pairs
+```typescript
+// WRONG - Breaks SDK integrity
+messages.push({ role: 'assistant', content: response });
+
+// RIGHT - Preserve SDK history
+await result.finalOutput;
+conversationHistory = (result as any).history;
+```
+
+### Handle Both Content Types
+```typescript
+.filter((item: any) => 
+  item.type === 'text' || item.type === 'output_text'
+)
+```
+
+## ArticleEndCritic Pattern
+
+Intelligent completion detection without disrupting flow:
+
+```typescript
+// Create AFTER writer's planning phase
+const planningResponse = extractPlanningResponse(result);
+const critic = createArticleEndCritic(planningResponse);
+
+// Check periodically
+if (sectionCount >= CHECK_START) {
+  const verdict = await checkCompletion(critic, writerOutputs);
+  if (verdict === 'YES') complete = true;
+}
+```
+
+## V2 vs V1 Comparison
+
+| Aspect | V1 (Orchestrator) | V2 (LLM-Driven) |
+|--------|-------------------|-----------------|
+| Code complexity | High | Low |
+| Output quality | Good | Excellent |
+| Debugging | Complex | Simple |
+| Prompts | In code | In database |
+| Tools | Many custom | Minimal |
+
+## Session Schema
+
+```sql
+CREATE TABLE v2_agent_sessions (
+  id UUID PRIMARY KEY,
+  workflow_id UUID NOT NULL,
+  status VARCHAR(50),
+  outline TEXT,          -- Long content
+  final_article TEXT,    -- AI output
+  error_message TEXT,    -- Can be long
+  session_metadata JSONB
+);
+```
+
+## Common Pitfalls
+
+1. **Adding instructions** - Breaks natural flow
+2. **END_OF_ARTICLE markers** - Causes premature ending  
+3. **Manual messages** - Breaks reasoning pairs
+4. **Wrong content type** - SDK varies format
+5. **Initial outline for critic** - Use writer's plan
+
+## Testing V2
+
+```bash
+# Check message integrity
+/api/admin/diagnose-article-v2
+
+# Verify prompts load from DB
+console.log('Prompts:', { PLANNING_PROMPT })
+
+# Monitor completion detection
+console.log('Critic verdict:', verdict)
+```
+
+## Migration Path
+
+1. Keep V1 working
+2. Add V2 toggle in UI
+3. Store prompts in database
+4. Test side-by-side
+5. Switch default when ready
+
+## Reference Implementation
+
+- Service: `/lib/services/agenticArticleV2Service.ts`
+- Agent: `/lib/agents/articleWriterV2.ts`
+- API: `/app/api/workflows/[id]/auto-generate-v2/`
+
+The V2 pattern proves simpler is better for LLM orchestration.

--- a/docs/architecture/COMPONENT_PATTERN.md
+++ b/docs/architecture/COMPONENT_PATTERN.md
@@ -1,0 +1,74 @@
+# Step Component Pattern
+
+> **Why**: Technical debt created two versions of each component  
+> **Use when**: Editing any step component  
+> **Outcome**: Edit the right file, avoid wasted time
+
+## The Problem
+
+Two versions exist for historical reasons:
+- `ArticleDraftStep.tsx` - ❌ DEPRECATED
+- `ArticleDraftStepClean.tsx` - ✅ ACTIVE
+
+## Finding the Active Version
+
+### 1. Check StepForm.tsx
+```typescript
+// components/StepForm.tsx line ~40-57
+const stepForms = {
+  'article-draft': ArticleDraftStepClean,     // ← This one!
+  'content-audit': ContentAuditStepClean,     // ← This one!
+  'final-polish': FinalPolishStepClean,       // ← This one!
+  // ... more mappings
+};
+```
+
+### 2. Quick Check Command
+```bash
+grep -n "ComponentName" components/StepForm.tsx
+```
+
+## Verification Process
+
+Before editing any step component:
+
+1. **Find imports**: `grep -r "ComponentName" --include="*.tsx"`
+2. **Check StepForm.tsx** mapping
+3. **Look for duplicates** with/without "Clean"
+4. **Edit only imported version**
+5. **Test changes appear** in UI
+
+## Current Active Components
+
+| Step | Active File | Deprecated |
+|------|------------|------------|
+| Article Draft | `ArticleDraftStepClean.tsx` | `ArticleDraftStep.tsx` |
+| Content Audit | `ContentAuditStepClean.tsx` | `ContentAuditStep.tsx` |
+| Final Polish | `FinalPolishStepClean.tsx` | `FinalPolishStep.tsx` |
+| Semantic Audit | `SemanticAuditStepClean.tsx` | `SemanticAuditStep.tsx` |
+
+## Common Mistakes
+
+### ❌ Editing deprecated file
+```bash
+# You edit ArticleDraftStep.tsx
+# Changes don't appear
+# Hours of confusion
+```
+
+### ✅ Correct approach
+```bash
+# Check StepForm.tsx first
+# Edit ArticleDraftStepClean.tsx
+# Changes work immediately
+```
+
+## Future Cleanup
+
+Eventually:
+1. Delete all deprecated files
+2. Rename Clean files to remove "Clean"
+3. Update all imports
+4. Document in migration guide
+
+For now: **Always check StepForm.tsx first!**

--- a/docs/archive/DEVELOPER_GUIDE_ORIGINAL.md
+++ b/docs/archive/DEVELOPER_GUIDE_ORIGINAL.md
@@ -1,0 +1,1630 @@
+# Guest Post Workflow v1.0.0 - Production Ready
+
+## Overview
+This is a **STABLE PRODUCTION VERSION** of the Guest Post Workflow application successfully deployed on Coolify with full PostgreSQL database integration.
+
+## Key Features Working
+- ✅ **Multi-user authentication** with PostgreSQL database
+- ✅ **Client management** with target pages persistence
+- ✅ **16-step workflow creation** with full data persistence
+- ✅ **Workflow step data saving** across all steps
+- ✅ **Multiple OpenAI account support** (3 accounts)
+
+## Critical Information
+
+### Database Configuration
+- **Database**: PostgreSQL on Coolify
+- **Connection**: Internal URL format required
+- **SSL**: Must be disabled (ssl: false)
+- **Schema**: Uses JSON storage for workflows (content field)
+
+### Authentication
+- Default admin: admin@example.com / admin123
+- All users visible in admin panel
+- Role-based access (user/admin)
+
+### Recent Fixes Applied
+1. **Workflow Creation** - Fixed schema mismatch, now uses JSON storage
+2. **Step Data Persistence** - Fixed PUT endpoint that was stubbed
+3. **Target Pages** - Created missing API endpoints for separate table
+4. **Multi-Account GPT Links** - Added support for 3 OpenAI accounts
+
+### OpenAI Accounts Supported
+- info@onlyoutreach.com (original)
+- ajay@pitchpanda.com
+- ajay@linkio.com
+
+## Architecture Notes
+
+### Database Schema
+```sql
+-- Main tables
+users (id, email, name, password_hash, role)
+clients (id, name, website, description, created_by)
+workflows (id, user_id, client_id, title, status, content, target_pages)
+target_pages (id, client_id, url, domain, status)
+workflow_steps (id, workflow_id, step_number, title, status, inputs, outputs)
+```
+
+### Key Services
+- `/lib/db/workflowService.ts` - Workflow CRUD with JSON storage
+- `/lib/db/clientService.ts` - Client and target pages management
+- `/lib/storage.ts` - Frontend API communication layer
+
+### API Endpoints
+- `/api/workflows` - GET/POST workflows
+- `/api/workflows/[id]` - GET/PUT/DELETE individual workflows
+- `/api/clients/[id]/target-pages` - GET/POST/PUT/DELETE target pages
+- `/api/database-checker` - System health diagnostics
+
+## Deployment Instructions
+
+### Environment Variables Required
+```env
+DATABASE_URL=postgresql://user:password@host:port/database?sslmode=disable
+NEXTAUTH_SECRET=your-secret-key
+NEXTAUTH_URL=https://your-domain.com
+```
+
+### Coolify Setup
+1. Deploy as Next.js application
+2. Set environment variables in Coolify
+3. Database will auto-initialize on first run
+4. Default admin account created automatically
+
+## Testing Tools Available
+- `/database-checker` - Full system analysis
+- `/api/workflows/[id]/validate` - Workflow validation
+- `/api/check-table-structure` - Database schema verification
+
+## Version History
+- **v1.0.0** (2025-01-02) - First stable production release
+  - All core features working
+  - Database persistence complete
+  - Multi-account support added
+  - All known bugs fixed
+
+## Important Notes for Future Development
+1. **Do NOT change** the JSON storage model for workflows - it's working
+2. **Always test** database operations locally before deployment
+3. **Target pages** are stored separately from clients (different table)
+4. **Workflow steps** data is stored within the workflow JSON content
+5. **Build must pass** before deployment - run `npm run build` to verify
+
+## CRITICAL: Step Component Technical Debt
+**🚨 BEFORE EDITING ANY STEP COMPONENTS - READ THIS FIRST 🚨**
+
+### The Problem
+There are TWO versions of step components due to technical debt:
+- **Original files** (e.g., `ArticleDraftStep.tsx`) - **DEPRECATED, NOT USED**
+- **Clean files** (e.g., `ArticleDraftStepClean.tsx`) - **ACTIVE IN PRODUCTION**
+
+### Which Files Are Actually Used
+Check `components/StepForm.tsx` - line 40-57 shows the REAL component mapping:
+```typescript
+const stepForms = {
+  'article-draft': ArticleDraftStepClean,     // NOT ArticleDraftStep
+  'content-audit': ContentAuditStepClean,    // NOT ContentAuditStep  
+  'final-polish': FinalPolishStepClean,      // NOT FinalPolishStep
+  // ... other steps
+};
+```
+
+### MANDATORY Process Before Editing Step Components
+1. **Find component imports first**: `grep -r "ComponentName" --include="*.tsx"`
+2. **Check StepForm.tsx** to see which version is actually used
+3. **Look for multiple versions** of the same component
+4. **Only edit the version that's imported in StepForm.tsx**
+5. **Verify changes appear** in files that are actually imported
+
+### Current Active Files (as of 2025-01-09)
+- `ArticleDraftStepClean.tsx` ✅ EDIT THIS
+- `ContentAuditStepClean.tsx` ✅ EDIT THIS  
+- `FinalPolishStepClean.tsx` ✅ EDIT THIS
+- `ArticleDraftStep.tsx` ❌ DO NOT EDIT (deprecated)
+- `ContentAuditStep.tsx` ❌ DO NOT EDIT (deprecated)
+- `FinalPolishStep.tsx` ❌ DO NOT EDIT (deprecated)
+
+## ⚠️ CRITICAL: Database VARCHAR Column Sizes for Agentic Features
+
+### The Hidden Killer: VARCHAR Size Limits
+
+**🚨 THIS WILL WASTE HOURS OF DEBUGGING TIME IF NOT ADDRESSED 🚨**
+
+When creating agentic features that save to PostgreSQL, **VARCHAR COLUMN SIZES ARE CRITICAL**. The agent will fail silently with vague "database error" messages if text exceeds column limits.
+
+#### Real-World Failures That Occurred:
+
+1. **polish_sections.polish_approach: varchar(100) → FAILED**
+   - Agent generated: "engagement-focused-with-semantic-clarity-balanced-approach"
+   - Error: Vague "Failed query" message, no indication it was length issue
+   - Fix: Must be `varchar(255)` minimum
+
+2. **polish_sections.title: varchar(255) → RISKY**
+   - Long titles with special characters exceed 255
+   - Fix: Use `varchar(500)` for safety
+
+3. **audit_sections.editing_pattern: varchar(100) → FAILED**
+   - Similar descriptive patterns as polish_approach
+   - Fix: Must be `varchar(255)` minimum
+
+#### When Creating ANY Agentic Table:
+
+```sql
+-- ❌ WRONG - Will cause silent failures
+CREATE TABLE agent_outputs (
+  approach VARCHAR(100),      -- TOO SMALL!
+  description VARCHAR(100),   -- TOO SMALL!
+  title VARCHAR(255)         -- RISKY!
+);
+
+-- ✅ CORRECT - Allows agent flexibility
+CREATE TABLE agent_outputs (
+  approach VARCHAR(255),      -- Safe for agent descriptions
+  description TEXT,          -- Use TEXT for long content
+  title VARCHAR(500),        -- Extra safe for titles
+  status VARCHAR(50)         -- OK for fixed values
+);
+```
+
+#### How to Debug VARCHAR Issues:
+
+1. **Symptoms:**
+   - Agent says "I encountered a database error"
+   - Server logs show "Failed query: insert into..."
+   - No clear error about column size
+
+2. **Diagnosis:**
+   - Go to `/admin/column-check` to see all column sizes
+   - Look for "❌ TOO SMALL" indicators
+   - Check if agent-generated content exceeds limits
+
+3. **Quick Fix:**
+   ```sql
+   ALTER TABLE table_name ALTER COLUMN column_name TYPE varchar(255);
+   ```
+
+#### Prevention Rules:
+
+1. **For agent-generated descriptions**: Use `VARCHAR(255)` minimum
+2. **For titles**: Use `VARCHAR(500)` 
+3. **For long content**: Use `TEXT` not VARCHAR
+4. **For status/type fields**: `VARCHAR(50)` is sufficient
+5. **When in doubt**: Use `TEXT` - better safe than sorry
+
+#### Testing New Agentic Features:
+
+Always create `/api/admin/check-column-sizes` endpoint to verify:
+- All VARCHAR columns in new tables
+- Compare against expected agent output lengths
+- Add "Fix Column Sizes" button in migration UI
+
+### Teams Workspace Button Added
+All three active step components now include the Teams Workspace button:
+- URL: https://chatgpt.com/g/g-p-686ea60485908191a5ac7a73ebf3a945/project?model=o3
+- Added alongside the three OpenAI account buttons
+
+## 🤖 AGENTIC AUTOMATION BEST PRACTICES
+
+### Overview
+This section documents proven patterns for building robust, production-ready AI agents using OpenAI Agents SDK. Based on successful implementations in `agenticArticleService.ts` and `agenticSemanticAuditService.ts`.
+
+### Core Architecture Pattern
+
+#### 1. Agent Service Class Structure
+```typescript
+export class AgenticServiceName {
+  private openaiProvider: OpenAIProvider;
+  
+  constructor() {
+    this.openaiProvider = new OpenAIProvider({
+      apiKey: process.env.OPENAI_API_KEY
+    });
+  }
+  
+  async startSession(params): Promise<string> { /* Session initialization */ }
+  async performTask(sessionId: string): Promise<void> { /* Main automation */ }
+  async getSession(sessionId: string) { /* Session retrieval */ }
+}
+```
+
+#### 2. Database Schema for Agent Sessions
+```sql
+-- Session tracking with versioning
+agent_sessions (
+  id, workflow_id, version, step_id, status,
+  total_sections, completed_sections, session_metadata,
+  started_at, completed_at, created_at, updated_at
+)
+
+-- Generated content by section/chunk
+content_sections (
+  id, session_id, section_number, title, content,
+  word_count, status, created_at, updated_at
+)
+```
+
+### Essential Agent Configuration
+
+#### 1. Agent Initialization Pattern
+```typescript
+const agent = new Agent({
+  name: 'AgentName',
+  instructions: 'Expert role description + AUTOMATED WORKFLOW continuation directive',
+  model: 'o3-2025-04-16', // Proven model for complex tasks
+  tools: [fileSearch, customTool1, customTool2] // Strategic tool selection
+});
+```
+
+**Key Instructions Elements:**
+- **Role Definition**: Clear expertise area and purpose
+- **Automation Directive**: "This is an AUTOMATED WORKFLOW - continue until completion without asking for permission"
+- **Output Guidelines**: Specific formatting and quality requirements
+- **Context Preservation**: Instructions for maintaining conversation flow
+
+#### 2. Tool Design Patterns
+
+**Zod Schema Validation (Required):**
+```typescript
+const toolSchema = z.object({
+  parameter: z.string().describe('Clear parameter description'),
+  count: z.number().describe('Specific numeric constraints'),
+  is_last: z.boolean().describe('Workflow continuation logic')
+});
+
+const customTool = tool({
+  name: "tool_name",
+  description: "Clear, specific tool purpose",
+  parameters: toolSchema,
+  execute: async (args) => {
+    // 1. Validation and data processing
+    // 2. Database operations
+    // 3. SSE progress updates
+    // 4. Return continuation context
+  }
+});
+```
+
+**Tool Categories:**
+- **Planning Tools**: Structure and analyze before execution
+- **Content Generation Tools**: Section-by-section creation with context
+- **Progress Tracking Tools**: Session state management
+- **Knowledge Tools**: File search integration for guidelines
+
+### Real-Time Streaming Architecture
+
+#### 1. Server-Sent Events (SSE) Pattern
+```typescript
+// Connection Management
+const activeStreams = new Map<string, any>();
+
+export function addSSEConnection(sessionId: string, res: any) {
+  activeStreams.set(sessionId, res);
+}
+
+export function removeSSEConnection(sessionId: string) {
+  activeStreams.delete(sessionId);
+}
+
+function sseUpdate(sessionId: string, payload: any) {
+  const stream = activeStreams.get(sessionId);
+  if (!stream) return;
+  try {
+    stream.write(`data: ${JSON.stringify(payload)}\n\n`);
+  } catch (error) {
+    console.error('SSE push failed:', error);
+  }
+}
+```
+
+#### 2. Progress Update Events
+```typescript
+// Event Types for UI Updates
+sseUpdate(sessionId, { type: 'status', status: 'planning', message: 'Analyzing outline...' });
+sseUpdate(sessionId, { type: 'section_completed', section_title, content, word_count });
+sseUpdate(sessionId, { type: 'completed', final_content, total_sections });
+```
+
+### Conversation Management
+
+#### 1. Message Flow Pattern
+```typescript
+const messages: any[] = [
+  { role: 'user', content: initialPrompt }
+];
+
+// Process agent responses systematically
+for await (const event of result.toStream()) {
+  if (event.name === 'tool_called') {
+    messages.push({
+      role: 'assistant',
+      tool_calls: [{ /* tool call data */ }]
+    });
+  }
+  
+  if (event.name === 'tool_output') {
+    messages.push({
+      role: 'tool',
+      content: toolOutput.output,
+      tool_call_id: toolOutput.tool_call_id
+    });
+  }
+}
+```
+
+#### 2. Automation Continuation Guards
+```typescript
+// Prevent agent from stopping mid-workflow
+if (conversationActive) {
+  messages.push({
+    role: 'user',
+    content: 'YOU MUST CONTINUE THE AUTOMATED WORKFLOW. DO NOT WAIT FOR PERMISSION.'
+  });
+}
+
+// Safety limits to prevent infinite loops
+if (messages.length > 100 || sectionCount > 20) {
+  conversationActive = false;
+  // Graceful workflow termination
+}
+```
+
+### Knowledge Base Integration
+
+#### 1. File Search Implementation
+```typescript
+// Vector store integration for guidelines and best practices
+const fileSearch = fileSearchTool(['vs_68710d7858ec8191b829a50012da7707']);
+
+// Usage in prompts
+const prompt = `
+REQUIRED ACTIONS:
+1. FIRST: Use file search to review relevant guidelines from knowledge base
+2. THEN: Apply guidelines to current task
+3. FINALLY: Execute task with learned context
+`;
+```
+
+#### 2. Knowledge Categories
+- **Style Guidelines**: Writing tone, format requirements
+- **SEO Best Practices**: Technical optimization rules
+- **Brand Guidelines**: Voice, terminology, constraints
+- **Quality Standards**: Output validation criteria
+
+### Error Handling & Recovery
+
+#### 1. Graceful Degradation
+```typescript
+try {
+  await performAgentTask(sessionId);
+} catch (error) {
+  console.error('Agent task failed:', error);
+  
+  // Update session status
+  await updateSession(sessionId, { 
+    status: 'failed', 
+    errorMessage: error.message 
+  });
+  
+  // Notify UI
+  sseUpdate(sessionId, { 
+    type: 'error', 
+    message: 'Agent encountered an error',
+    canRetry: true 
+  });
+}
+```
+
+#### 2. Session Recovery
+```typescript
+// Resume interrupted sessions
+async resumeSession(sessionId: string) {
+  const session = await getSession(sessionId);
+  if (session.status === 'failed' || session.status === 'interrupted') {
+    const lastCompletedSection = session.completedSections || 0;
+    // Continue from last successful point
+    return this.performTask(sessionId, { resumeFrom: lastCompletedSection });
+  }
+}
+```
+
+### Production Deployment Considerations
+
+#### 1. Environment Configuration
+```env
+OPENAI_API_KEY=sk-...           # Primary API key
+OPENAI_API_KEY_BACKUP=sk-...    # Backup for rate limiting
+VECTOR_STORE_ID=vs_...          # Knowledge base ID
+AGENT_TIMEOUT_MS=300000         # 5 minute timeout
+```
+
+#### 2. Monitoring & Logging
+```typescript
+// Detailed logging for production debugging
+console.log(`🤖 Agent session ${sessionId}: Starting ${taskName}`);
+console.log(`📊 Progress: ${completed}/${total} sections completed`);
+console.log(`⏱️ Processing time: ${duration}ms`);
+console.log(`💰 Token usage: ${inputTokens}/${outputTokens}`);
+```
+
+### Performance Optimization
+
+#### 1. Chunking Strategy
+- **Section-by-Section Processing**: Prevents token limit issues
+- **Context Preservation**: Maintain previous sections for flow
+- **Parallel Processing**: Multiple agents for independent tasks
+
+#### 2. Rate Limiting
+```typescript
+// Implement delays between API calls
+await new Promise(resolve => setTimeout(resolve, 1000));
+
+// Use multiple API keys for higher throughput
+const apiKey = this.getAvailableApiKey();
+```
+
+### Proven Models & Settings
+
+#### 1. Model Selection
+- **Primary**: `o3-2025-04-16` - Best for complex reasoning and tool usage
+- **Fallback**: `gpt-4-turbo` - Reliable performance for simpler tasks
+- **Avoid**: `gpt-3.5-turbo` - Insufficient for complex agentic workflows
+
+#### 2. Runner Configuration
+```typescript
+const runner = new Runner({
+  modelProvider: this.openaiProvider,
+  tracingDisabled: true,    // Performance optimization
+  maxRetries: 3,           // Error resilience
+  timeout: 300000          // 5 minute timeout
+});
+```
+
+### Success Metrics
+
+#### 1. Quality Indicators
+- **Completion Rate**: % of sessions that finish successfully
+- **Content Quality**: Human evaluation scores
+- **Automation Level**: % reduction in manual intervention
+- **Processing Time**: Average time per section/task
+
+#### 2. Technical Metrics
+- **Token Efficiency**: Tokens per output unit
+- **Error Rate**: Failed sessions per total attempts
+- **Recovery Rate**: Successfully resumed sessions
+- **User Satisfaction**: Feedback scores
+
+**Reference Implementations:**
+- Article Generation: `/lib/services/agenticArticleService.ts`
+- Semantic SEO Audit: `/lib/services/agenticSemanticAuditService.ts`
+- UI Components: `/components/ui/AgenticArticleGenerator.tsx`
+- API Endpoints: `/app/api/workflows/[id]/auto-generate/stream/route.ts`
+
+## 🔧 MANDATORY DIAGNOSTIC PROTOCOL FOR AGENTIC FEATURES
+
+### THE PROBLEM: Hours of Debugging Without Root Cause Analysis
+
+**🚨 CRITICAL ISSUE**: When implementing agentic features, vague database errors waste 4-6 hours of back-and-forth debugging. This protocol prevents that.
+
+### 🚨 CRITICAL: WHEN TO USE THIS DIAGNOSTIC PROTOCOL
+
+**USE DIAGNOSTICS FOR:**
+- ✅ **Debugging implementation issues** after building agentic features
+- ✅ **Verifying database integration** when errors occur
+- ✅ **Troubleshooting vague database errors** in any agentic feature
+- ✅ **Ensuring correct implementation** after development is complete
+
+**PROPER WORKFLOW:**
+```
+1. Build the agentic feature implementation
+2. Test the implementation
+3. IF errors occur → USE DIAGNOSTICS to identify root cause
+4. Fix issues based on diagnostic results
+5. Deploy working implementation
+```
+
+**WHY THIS APPROACH:**
+- Diagnostics are **debugging tools**, not planning tools
+- You need a working implementation first to diagnose issues
+- Build first, then troubleshoot with diagnostics if needed
+- Diagnostics help fix problems, not prevent them upfront
+
+### DIAGNOSTIC TOOLS: Create These When Debugging Agentic Features
+
+#### 1. Comprehensive Database Diagnostics (`/admin/diagnostics`)
+**Purpose**: Understand the ACTUAL database structure vs. what the code expects
+
+**Required Features**:
+- Schema analysis for all tables
+- Missing column detection
+- Data storage pattern analysis (JSON vs. separate tables)
+- Sample data structure examination
+- Primary diagnosis with specific recommendations
+
+**Code Pattern**:
+```typescript
+// /app/api/admin/comprehensive-diagnostics/route.ts
+export async function GET() {
+  const diagnostics = {
+    tableSchemas: {},
+    sampleData: {},
+    issues: [],
+    recommendations: [],
+    diagnosis: {
+      primaryIssue: 'Specific root cause',
+      likelyRoot: 'Why this is happening',
+      immediateAction: 'Exact fix needed'
+    }
+  };
+  
+  // Analyze each table structure
+  for (const tableName of requiredTables) {
+    const schema = await getTableSchema(tableName);
+    diagnostics.tableSchemas[tableName] = schema;
+    
+    // Check for missing expected columns
+    const missingColumns = expectedColumns.filter(col => !schema.columns.includes(col));
+    if (missingColumns.length > 0) {
+      diagnostics.issues.push({
+        severity: 'CRITICAL',
+        table: tableName,
+        message: `Missing expected columns: ${missingColumns.join(', ')}`,
+        recommendation: 'Update queries to read from actual data structure'
+      });
+    }
+  }
+  
+  return diagnostics;
+}
+```
+
+#### 2. VARCHAR Column Analysis (`/admin/varchar-limits`)
+**Purpose**: Prevent "Failed query: insert" errors from VARCHAR size limits
+
+**Required Features**:
+- Check all VARCHAR columns in agentic tables
+- Identify columns too small for AI-generated content
+- Auto-fix button to expand to TEXT/appropriate sizes
+- Test with sample AI-generated content
+
+**Critical Columns to Check**:
+- Any column storing AI descriptions: `VARCHAR(255)` minimum
+- Title fields: `VARCHAR(500)` minimum  
+- Long content: `TEXT` type
+- Status/type fields: `VARCHAR(50)` is sufficient
+
+**Code Pattern**:
+```typescript
+// /app/api/admin/check-varchar-limits/route.ts
+export async function POST() {
+  const fixes = [
+    { column: 'check_description', type: 'TEXT' },
+    { column: 'issues_found', type: 'TEXT' },
+    { column: 'fix_suggestions', type: 'TEXT' }
+  ];
+  
+  for (const fix of fixes) {
+    await db.execute(sql`
+      ALTER TABLE ${tableName} 
+      ALTER COLUMN ${fix.column} TYPE ${fix.type}
+    `);
+  }
+}
+```
+
+#### 3. PostgreSQL Error Capture (`/admin/test-database-inserts`)
+**Purpose**: Capture EXACT PostgreSQL error details, not vague "database error" messages
+
+**Required Features**:
+- Test exact failing INSERT with real data
+- Capture detailed PostgreSQL error codes and messages
+- Identify specific data type mismatches
+- Test fixes with same data
+
+**Critical Error Patterns**:
+- `invalid input syntax for type integer: "8.5"` → Use `Math.round()` for integers
+- `null value in column violates not-null constraint` → Use empty string `''` instead of `null`
+- `value too long for type character varying(N)` → Increase VARCHAR size
+
+**Code Pattern**:
+```typescript
+// /app/api/admin/test-database-inserts/route.ts
+export async function POST() {
+  const testData = { /* exact failing data */ };
+  
+  try {
+    await db.execute(sql`INSERT INTO table_name VALUES (...)`);
+  } catch (error) {
+    return {
+      postgresError: {
+        code: error.code,
+        detail: error.detail,
+        hint: error.hint,
+        message: error.message,
+        severity: error.severity
+      },
+      diagnosis: analyzeError(error)
+    };
+  }
+}
+```
+
+#### 4. Database Migration Verification (`/admin/database-migration`)
+**Purpose**: Ensure all required tables exist with correct structure
+
+**Required Features**:
+- Check table existence for each agentic feature
+- Verify column types match expectations
+- Migration buttons for each feature
+- Rollback capability
+
+### WORKFLOW: Systematic Troubleshooting Process
+
+#### Phase 1: Database Structure Analysis (5 minutes)
+1. **Run comprehensive diagnostics** → `/admin/diagnostics`
+2. **Identify schema mismatches** → Look for missing columns, wrong data storage patterns
+3. **Check actual vs. expected structure** → Fix queries to match reality
+
+#### Phase 2: Column Size Verification (3 minutes)
+1. **Run VARCHAR analysis** → `/admin/varchar-limits`
+2. **Fix any columns < 255 chars** → Auto-fix to TEXT/appropriate sizes
+3. **Verify agent-generated content fits** → Test with sample data
+
+#### Phase 3: Error Root Cause Analysis (2 minutes)
+1. **Capture exact PostgreSQL errors** → `/admin/test-database-inserts`
+2. **Identify specific data type issues** → Integer vs. decimal, null constraints
+3. **Test fixes with same data** → Verify fixes work
+
+#### Phase 4: Migration Verification (2 minutes)
+1. **Verify all tables exist** → `/admin/database-migration`
+2. **Check column types** → Ensure they match code expectations
+3. **Run any missing migrations** → Fix schema issues
+
+### COMMON FAILURE PATTERNS & FIXES
+
+#### 1. Schema Assumption Failures
+**Symptom**: "column does not exist" errors
+**Root Cause**: Code assumes `workflow_steps` table but data is in `workflows.content.steps` JSON
+**Fix**: Update queries to read from actual data structure
+```typescript
+// ❌ Wrong assumption
+const workflow = await db.query.workflows.findFirst({
+  with: { steps: true } // This table might not exist
+});
+
+// ✅ Correct approach
+const workflow = await db.query.workflows.findFirst({
+  where: eq(workflows.id, workflowId)
+});
+const steps = workflow.content?.steps || [];
+```
+
+#### 2. VARCHAR Size Failures
+**Symptom**: "Failed query: insert" with no clear error
+**Root Cause**: AI-generated content exceeds VARCHAR limits
+**Fix**: Use TEXT for AI content, VARCHAR(255+) for descriptions
+```sql
+-- ❌ Too small for AI content
+ALTER TABLE formatting_qa_checks ALTER COLUMN check_description TYPE VARCHAR(100);
+
+-- ✅ Safe for AI content
+ALTER TABLE formatting_qa_checks ALTER COLUMN check_description TYPE TEXT;
+```
+
+#### 3. Data Type Mismatches
+**Symptom**: "invalid input syntax for type integer"
+**Root Cause**: Sending decimals to integer columns
+**Fix**: Round/convert data before insert
+```typescript
+// ❌ Sending decimal to integer column
+confidenceScore: args.confidence, // 8.5 → fails
+
+// ✅ Round to integer
+confidenceScore: Math.round(args.confidence), // 8.5 → 9
+```
+
+#### 4. NULL Constraint Violations
+**Symptom**: "null value in column violates not-null constraint"
+**Root Cause**: Sending null to NOT NULL columns
+**Fix**: Use empty string or appropriate defaults
+```typescript
+// ❌ Sending null to NOT NULL column
+errorMessage: null, // fails if column is NOT NULL
+
+// ✅ Use empty string
+errorMessage: '', // works for NOT NULL TEXT columns
+```
+
+### MANDATORY ADMIN UI PAGES FOR AGENTIC FEATURES
+
+After implementing any agentic feature, these admin pages MUST be created/updated:
+
+#### 1. Database Migration Management (`/admin/database-migration`)
+**REQUIRED UI ELEMENTS:**
+- **Check Button**: Verify if tables exist and are properly structured
+- **Create Button**: Run database migration to create tables
+- **Remove Button**: Rollback migration (drop tables)
+- **Status Display**: Show current migration state for each feature
+
+**Example for formatting QA:**
+```
+Formatting QA Tables:
+[✅ Check] [🔧 Create] [🗑️ Remove]
+Status: Tables exist and properly configured
+```
+
+#### 2. Diagnostic Tools Frontend Pages
+**REQUIRED PAGES:**
+- **`/admin/diagnostics`** → Comprehensive database structure analysis
+- **`/admin/varchar-limits`** → Column size verification and auto-fixing
+- **`/admin/fix-formatting-qa`** → Feature-specific diagnostic tools
+- **`/admin/column-check`** → General column analysis across all tables
+
+**Each diagnostic page MUST have:**
+- **Run Analysis Button**: Execute diagnostic checks
+- **Auto-Fix Button**: Apply recommended fixes automatically
+- **Status Display**: Show current issues and their severity
+- **Detailed Results**: Table schemas, column sizes, error details
+
+#### 3. Feature-Specific Diagnostic Pages
+**For each agentic feature (e.g., formatting QA), create:**
+- **`/admin/fix-[feature-name]`** → Feature-specific diagnostic tools
+- **Check Functions**: Analyze tables specific to that feature
+- **Fix Functions**: Auto-repair column sizes, constraints, etc.
+- **Test Functions**: Verify the feature works with real data
+
+**Example Structure:**
+```
+/admin/fix-formatting-qa
+├── Check Tables → Verify formatting_qa_sessions, formatting_qa_checks exist
+├── Fix Columns → Auto-expand VARCHAR to TEXT where needed
+├── Test Insert → Verify real data insertion works
+└── Migration Status → Show current state and recommend actions
+```
+
+#### 4. Admin Navigation Integration
+**Update `/admin` navigation to include:**
+- **Database Migration** → Central migration management
+- **Diagnostics** → Comprehensive system analysis
+- **Column Check** → VARCHAR size verification
+- **Feature Diagnostics** → Links to each feature-specific diagnostic page
+
+#### 5. Required API Endpoints for UI Pages
+**For each admin page, ensure these endpoints exist:**
+- **GET** → Retrieve current status and analysis
+- **POST** → Execute fixes and migrations
+- **DELETE** → Rollback migrations when needed
+
+**Example API structure:**
+```
+/api/admin/migrate-[feature] → GET/POST/DELETE
+/api/admin/fix-[feature]-columns → GET/POST  
+/api/admin/check-[feature]-tables → GET
+/api/admin/test-[feature]-insert → POST
+```
+
+### MANDATORY WORKFLOW: ADMIN UI CREATION
+
+**When implementing ANY agentic feature, follow this workflow:**
+
+#### Phase 1: API Endpoints (Backend)
+1. **Create migration endpoint**: `/api/admin/migrate-[feature]` (GET/POST/DELETE)
+2. **Create diagnostic endpoint**: `/api/admin/fix-[feature]-columns` (GET/POST)
+3. **Create table check endpoint**: `/api/admin/check-[feature]-tables` (GET)
+4. **Create test endpoint**: `/api/admin/test-[feature]-insert` (POST)
+
+#### Phase 2: Frontend Pages (UI)
+1. **Update `/admin/database-migration`**: Add new feature section with Check/Create/Remove buttons
+2. **Create `/admin/fix-[feature]`**: Feature-specific diagnostic page
+3. **Update `/admin/diagnostics`**: Include new feature in comprehensive analysis
+4. **Update admin navigation**: Add links to new diagnostic pages
+
+#### Phase 3: Integration Testing
+1. **Test migration flow**: Check → Create → Remove → Create again
+2. **Test diagnostic flow**: Analyze → Fix → Verify
+3. **Test with real data**: Ensure feature works end-to-end
+4. **Document in CLAUDE.md**: Update this file with new admin pages
+
+### ADMIN PAGE REQUIREMENTS CHECKLIST
+
+**For every new agentic feature, verify these admin pages exist:**
+
+- [ ] **`/admin/database-migration`** → Feature included with Check/Create/Remove buttons
+- [ ] **`/admin/fix-[feature]`** → Feature-specific diagnostic page created
+- [ ] **`/admin/diagnostics`** → Feature included in comprehensive analysis
+- [ ] **`/admin/varchar-limits`** → Feature tables included in VARCHAR analysis
+- [ ] **`/admin/column-check`** → Feature tables included in column analysis
+
+**Each page must have:**
+- [ ] **Status indicators** → Show current state (✅ Working, ❌ Issues, ⚠️ Warnings)
+- [ ] **Action buttons** → Check, Fix, Test, Create, Remove
+- [ ] **Detailed results** → Table schemas, column info, error messages
+- [ ] **Auto-fix capability** → One-click resolution for common issues
+
+### PREVENTION RULES
+
+1. **Always build admin UI pages** → Don't leave diagnostics as API-only
+2. **Test with real AI-generated content** → Don't use short test strings
+3. **Capture exact PostgreSQL errors** → Don't settle for vague messages
+4. **Use TEXT for AI content** → Don't risk VARCHAR limits
+5. **Verify schema matches code** → Don't assume table structure
+
+### SUCCESS CRITERIA
+
+- **10 minutes to diagnose any issue** → Down from 4-6 hours
+- **Specific error messages** → No more guessing
+- **Automated fixes** → One-click solutions
+- **Prevention built-in** → Issues caught before deployment
+
+This protocol prevents the expensive debugging cycles that occurred with the formatting QA feature implementation.
+
+### FORMATTING QA IMPLEMENTATION EXAMPLE
+
+**The formatting QA feature demonstrates proper admin UI implementation:**
+
+#### Admin Pages Created:
+- **`/admin/database-migration`** → Includes formatting QA section with Check/Create/Remove buttons
+- **`/admin/fix-formatting-qa`** → Feature-specific diagnostics for formatting QA tables
+- **`/admin/diagnostics`** → Includes formatting QA in comprehensive analysis
+- **`/admin/varchar-limits`** → Includes formatting_qa_sessions and formatting_qa_checks tables
+- **`/admin/column-check`** → Analyzes all formatting QA columns
+
+#### API Endpoints Created:
+- **`/api/admin/migrate-formatting-qa`** → GET/POST/DELETE for table management
+- **`/api/admin/fix-formatting-qa-columns`** → GET/POST for column size fixes
+- **`/api/admin/check-formatting-qa-tables`** → GET for table existence verification
+- **`/api/admin/test-formatting-qa-insert`** → POST for real data testing
+- **`/api/admin/diagnose-formatting-qa-enhancement`** → GET for enhancement analysis
+
+#### UI Features Available:
+- **Migration Status**: Shows if tables exist and are properly configured
+- **Auto-Fix Columns**: One-click fix for VARCHAR → TEXT conversions
+- **Test Data Insertion**: Verify real AI-generated content works
+- **Comprehensive Analysis**: Full diagnostic report with specific recommendations
+- **Error Capture**: Exact PostgreSQL error messages with solutions
+
+**This serves as the template for all future agentic feature implementations.**
+
+## 🔧 AGENTIC WORKFLOW FIX: Agent Text Response Retry Logic
+
+### The Problem: Agents Output Text Instead of Tools
+
+**🚨 CRITICAL ISSUE**: OpenAI Agents SDK allows agents to output explanatory text instead of using required tools, causing workflow failures.
+
+**Symptoms:**
+- "Cannot read properties of null" errors
+- Agents output progress updates instead of using tools
+- Workflow gets stuck waiting for tool calls that never come
+- Verbose guard rail messages accumulate in conversation history
+
+**Root Cause:**
+```typescript
+// ❌ PROBLEMATIC CODE: Adds agent text responses to message history
+if (event.name === 'message_output_created') {
+  const messageItem = event.item as any;
+  
+  if (!messageItem.tool_calls?.length) {
+    messages.push({
+      role: 'assistant',
+      content: messageItem.content  // Teaches agent text is acceptable
+    });
+  }
+}
+```
+
+### The Solution: ChatGPT's Retry Fix Pattern
+
+**✅ PROVEN FIX**: Immediate detection and clean retry, preventing message history pollution.
+
+#### 1. Create Utility Functions (`/lib/utils/agentUtils.ts`)
+
+```typescript
+/**
+ * Detects when an assistant sends plain text instead of using tools
+ */
+export function assistantSentPlainText(event: any): boolean {
+  return (
+    event.type === 'run_item_stream_event' &&
+    event.name === 'message_output_created' &&
+    !event.item.tool_calls?.length
+  );
+}
+
+/**
+ * Service-specific retry nudges
+ */
+export const SEMANTIC_AUDIT_RETRY_NUDGE =
+  '🚨 FORMAT INVALID – respond ONLY by calling the audit_section function. ' +
+  'Do NOT output progress updates.';
+
+export const ARTICLE_WRITING_RETRY_NUDGE =
+  '🚨 FORMAT INVALID – respond ONLY by calling the write_section function. ' +
+  'Do NOT output progress updates.';
+
+export function createRetryNudge(expectedTool: string): string {
+  return `🚨 FORMAT INVALID – respond ONLY by calling the ${expectedTool} function. ` +
+         'Do NOT output progress updates.';
+}
+```
+
+#### 2. Apply Fix Pattern to Agentic Services
+
+**STEP 1: Add Import**
+```typescript
+import { assistantSentPlainText, SEMANTIC_AUDIT_RETRY_NUDGE } from '@/lib/utils/agentUtils';
+```
+
+**STEP 2: Add Retry Variables**
+```typescript
+let conversationActive = true;
+let sectionCount = 0;
+let retries = 0;
+const MAX_RETRIES = 3;
+
+while (conversationActive) {
+```
+
+**STEP 3: Add Immediate Detection in Stream Loop**
+```typescript
+// Process the streaming result
+for await (const event of result.toStream()) {
+  // ✨ NEW: Immediate detection and retry for plain text responses
+  if (assistantSentPlainText(event)) {
+    // Don't record the bad message, just nudge and restart next turn
+    messages.push({ role: 'system', content: SEMANTIC_AUDIT_RETRY_NUDGE });
+    retries += 1;
+    if (retries > MAX_RETRIES) {
+      throw new Error('Too many invalid assistant responses - agent not using tools');
+    }
+    break; // Exit this for-await; outer while() will re-run
+  }
+  
+  // ... rest of event handling
+```
+
+**STEP 4: Replace Problematic Message Handler**
+```typescript
+// REMOVE old problematic handler:
+if (event.name === 'message_output_created') {
+  const messageItem = event.item as any;
+  
+  if (!messageItem.tool_calls?.length) {
+    messages.push({  // ❌ This pollutes conversation history
+      role: 'assistant',
+      content: messageItem.content
+    });
+    // ... verbose guard rail logic
+  }
+}
+
+// ✅ REPLACE with clean handler:
+if (event.name === 'message_output_created') {
+  const messageItem = event.item as any;
+  
+  // Only handle tool call messages - plain text is caught above
+  if (messageItem.tool_calls?.length) {
+    retries = 0; // Reset retry counter on successful tool usage
+  }
+}
+```
+
+### Implementation Checklist
+
+**For each agentic service:**
+
+- [ ] **Import agentUtils**: Add import statement
+- [ ] **Add retry variables**: `retries`, `MAX_RETRIES = 3`
+- [ ] **Add detection logic**: `assistantSentPlainText()` check at top of stream loop
+- [ ] **Remove old handler**: Delete problematic `message_output_created` logic
+- [ ] **Add clean handler**: Reset retries on successful tool usage
+- [ ] **Test thoroughly**: Verify retry logic works, no regressions
+
+### Services Successfully Fixed
+
+✅ **agenticSemanticAuditService.ts** - Fixed and working excellently  
+🔄 **agenticArticleService.ts** - In progress  
+⏳ **agenticFormattingQAService.ts** - Planned  
+⏳ **agenticFinalPolishService.ts** - Planned  
+
+### Key Benefits
+
+1. **🚫 Prevents History Pollution**: Bad messages never enter conversation
+2. **⚡ Immediate Restart**: `break` triggers outer `while()` to retry
+3. **💪 System Authority**: System messages carry more weight than user messages
+4. **🛡️ Safety Limits**: Maximum 3 retries prevent infinite loops
+5. **🎯 Targeted Nudges**: Service-specific retry messages
+
+### Testing Strategy
+
+**Required Tests for Each Service:**
+1. **Normal flow**: Complete workflow without text responses
+2. **Text response recovery**: Agent outputs text, retry logic fixes it
+3. **Mid-workflow retry**: Agent stops mid-process, successfully recovers
+4. **Retry limit**: Workflow fails gracefully after 3 attempts
+5. **Data consistency**: Database state preserved through retries
+
+**Success Metrics:**
+- ✅ Completion rate: Workflows finish without manual intervention
+- ✅ Retry effectiveness: Text responses recovered within 3 attempts  
+- ✅ Data consistency: Session state remains accurate through retries
+- ✅ No regression: Existing functionality continues working
+
+### Reference Implementation
+
+See `agenticSemanticAuditService.ts` for complete working example of this fix pattern applied successfully.
+
+## 🚀 V2 ARTICLE GENERATION: TRUE LLM ORCHESTRATION (PRODUCTION READY)
+
+### Overview
+V2 represents a fundamental shift from code-driven orchestration to true LLM orchestration. Instead of complex agent-as-tool patterns, V2 implements a single conversation thread where the LLM naturally progresses through the article generation process using database prompts.
+
+**Key Innovation**: The "magic" of manual ChatGPT.com workflows is recreated by maintaining full conversation context and using exact prompts from the database, allowing the LLM to drive the process naturally.
+
+**Production Status**: ✅ FULLY WORKING with ArticleEndCritic for intelligent completion detection
+
+**Latest Enhancements (2025-01-19)**:
+- ✅ Dynamic outline-based completion detection using writer's generated outline
+- ✅ Increased section limit from 20 to 40 sections
+- ✅ Fixed progress display to avoid confusing 100%, 200% percentages
+- ✅ ArticleEndCritic using o4-mini model for robust detection
+- ✅ Improved prompt for better completion criteria
+
+### Architecture Pattern
+
+#### 1. Single Agent, Single Conversation
+```typescript
+// One agent with minimal configuration
+export const writerAgentV2 = new Agent({
+  name: 'ArticleWriterV2',
+  instructions: '', // CRITICAL: Empty instructions - all guidance comes from prompts
+  model: 'o3-2025-04-16',
+  tools: [fileSearch], // Only vector store access, no custom tools
+});
+
+// One runner, one continuous conversation
+const writerRunner = new Runner({
+  modelProvider: this.openaiProvider,
+  tracingDisabled: true
+});
+```
+
+#### 2. Database-Driven Prompts
+```typescript
+// Three exact prompts from database fields
+const PLANNING_PROMPT = `Okay, I'm about to give you a lot of information...`;
+const TITLE_INTRO_PROMPT = `Yes, remember we're going to be creating this article section by section...`;
+const LOOPING_PROMPT = `Proceed to the next section...`;
+```
+
+#### 3. Natural Progression Pattern
+```typescript
+// Phase 1: Planning
+conversationHistory = [{ role: 'user', content: `${PLANNING_PROMPT}\n\n${outline}` }];
+let result = await writerRunner.run(agent, conversationHistory, { stream: true });
+
+// Phase 2: Title/Intro
+conversationHistory.push({ role: 'user', content: TITLE_INTRO_PROMPT });
+result = await writerRunner.run(agent, conversationHistory, { stream: true });
+
+// Phase 3: Looping sections
+while (!articleComplete) {
+  conversationHistory.push({ role: 'user', content: LOOPING_PROMPT });
+  result = await writerRunner.run(agent, conversationHistory, { stream: true });
+}
+```
+
+### Critical Bug Fixes & Lessons Learned
+
+#### 1. Message-Reasoning Pair Integrity
+**Problem**: "400 Item was provided without its required 'reasoning' item"
+**Root Cause**: Manually building messages breaks the SDK's message-reasoning pairing
+**Solution**: Always use SDK's complete history
+```typescript
+// ❌ WRONG: Manual message building
+messages.push({ role: 'assistant', content: response });
+
+// ✅ CORRECT: Use SDK history after run completes
+await result.finalOutput; // CRITICAL: Wait for completion
+conversationHistory = (result as any).history; // Includes reasoning pairs
+```
+
+#### 2. Content Type Compatibility
+**Problem**: "No planning response extracted" 
+**Root Cause**: SDK uses 'output_text' for streamed runs, not 'text'
+**Solution**: Handle both content types
+```typescript
+// ✅ CORRECT: Accept both formats
+.filter((item: any) => 
+  item.type === 'text' || item.type === 'output_text'
+)
+```
+
+#### 3. History Timing Issue
+**Problem**: "Assistant message missing reasoning pair"
+**Root Cause**: Copying history before run completes
+**Solution**: Proper sequencing
+```typescript
+// ✅ CORRECT ORDER:
+// 1. Start the run
+let result = await writerRunner.run(agent, conversationHistory, { stream: true });
+
+// 2. Consume the stream
+for await (const event of result.toStream()) { /* ... */ }
+
+// 3. Wait for completion
+await result.finalOutput;
+
+// 4. NOW copy history
+conversationHistory = (result as any).history;
+```
+
+#### 4. Model Selection for ArticleEndCritic
+**Problem**: "We tried to use O2 mini for the Judge Agent. That doesn't work."
+**Evolution**: 
+- ❌ o2-mini → Model doesn't exist
+- ✅ gpt-4.1-nano → Worked but suboptimal
+- ✅ o4-mini → Final choice, best performance
+
+#### 5. Dynamic Outline Usage
+**Problem**: "the ai just guesses" when using initial outline
+**Solution**: Use writer's generated outline from planning phase
+```typescript
+// NOW create ArticleEndCritic with the writer's generated outline
+articleEndCritic = createArticleEndCritic(planningResponse);
+console.log(`🎯 Created ArticleEndCritic with writer's generated outline`);
+
+// Recalculate CHECK_START based on the writer's outline
+const planningLines = planningResponse.split('\n');
+const plannedSections = planningLines.filter(line => /^\d+\./.test(line.trim())).length;
+const expectedSections = Math.max(5, plannedSections);
+CHECK_START = Math.max(5, Math.floor(expectedSections * 0.6));
+```
+
+#### 6. Streaming Without Disruption
+**Pattern**: Stream content while preserving SDK integrity
+```typescript
+for await (const event of result.toStream()) {
+  if (event.type === 'raw_model_stream_event' && 
+      event.data.type === 'output_text_delta') {
+    sseUpdate(sessionId, { type: 'text', content: event.data.delta });
+  }
+}
+```
+
+#### 7. Progress Display Fix
+**Problem**: "100%, then 200% etc" when sections unknown
+**Solution**: Show section count instead of percentage when total unknown
+```typescript
+// Don't calculate percentage when we don't know total sections
+const hasKnownTotal = progress?.session.totalSections && progress.session.totalSections > 0;
+const progressPercentage = hasKnownTotal
+  ? Math.round((progress.session.completedSections / progress.session.totalSections) * 100) 
+  : 0;
+
+// Display logic
+hasKnownTotal 
+  ? `${progressPercentage}% Complete`
+  : `${progress.session.completedSections} sections completed`
+```
+
+### Implementation Checklist
+
+#### Database Schema
+```sql
+-- V2 uses TEXT columns for AI content (learning from VARCHAR failures)
+CREATE TABLE v2_agent_sessions (
+  id UUID PRIMARY KEY,
+  outline TEXT,              -- Long research content
+  final_article TEXT,        -- Complete article
+  error_message TEXT,        -- Error details
+  session_metadata JSONB     -- Flexible metadata
+);
+```
+
+#### Service Structure
+```typescript
+export class AgenticArticleV2Service {
+  async startSession(workflowId: string, outline: string): Promise<string>
+  async performArticleGeneration(sessionId: string): Promise<void>
+  private async saveArticleToWorkflow(workflowId: string, article: string)
+  private async getSession(sessionId: string)
+  private async updateSession(sessionId: string, updates: Partial<any>)
+}
+```
+
+#### Error Handling
+```typescript
+try {
+  // Main generation logic
+} catch (error: any) {
+  console.error('❌ V2 article generation failed:', error);
+  await this.updateSession(sessionId, {
+    status: 'failed',
+    errorMessage: error.message
+  });
+  sseUpdate(sessionId, { type: 'error', error: error.message });
+  throw error;
+}
+```
+
+### V2 Best Practices
+
+#### 1. Maintain Conversation Integrity
+- Never manually construct assistant messages
+- Always use SDK's complete history
+- Wait for `finalOutput` before copying history
+- Preserve message-reasoning pairs
+
+#### 2. Handle Content Formats
+- Support both 'text' and 'output_text' types
+- Extract content safely from arrays
+- Handle string content as fallback
+- Clean end markers from output
+
+#### 3. Natural Flow Control
+- ArticleEndCritic for intelligent completion detection
+- Safety limits (40 sections max - increased from 20)
+- Track progress with writerOutputs array
+- Skip planning output from final article
+- Dynamic CHECK_START based on outline analysis
+
+#### 4. Database Design
+- Use TEXT columns for all AI content
+- Avoid VARCHAR constraints
+- Store complete conversation in session
+- Track version numbers for iterations
+
+#### 5. Streaming Architecture
+- Stream deltas to frontend via SSE
+- Don't store streaming fragments
+- Extract final content from SDK history
+- Maintain active connection registry
+
+### Migration from V1 to V2
+
+#### Key Differences
+1. **No Orchestrator**: Single agent handles everything
+2. **No Custom Tools**: Pure conversation flow
+3. **Database Prompts**: Exact prompts from UI fields
+4. **Full Context**: Maintains conversation throughout
+5. **Natural Progression**: LLM decides when complete
+
+#### UI Integration
+```typescript
+// Article Draft Step Clean - Add V2 Toggle
+const [useV2, setUseV2] = useState(false);
+
+// Conditional generation
+if (useV2) {
+  await generateArticleV2(workflowId, researchData);
+} else {
+  await generateArticle(workflowId, researchData);
+}
+```
+
+### Testing V2 Implementation
+
+#### 1. Diagnostic Tools
+- `/admin/fix-article-v2` - V2-specific diagnostics
+- `/api/admin/diagnose-article-v2` - System analysis
+- Message format validation
+- Session status tracking
+
+#### 2. Common Issues & Solutions
+- **Empty response**: Check content type filters
+- **Missing history**: Ensure `await finalOutput`
+- **Reasoning errors**: Use SDK history, not manual
+- **No output**: Verify prompts match database
+
+#### 3. Success Metrics
+- Natural, conversational output
+- Consistent quality across sections
+- Proper citation integration
+- Maintains brand voice throughout
+
+### Reference Implementation
+- **Service**: `/lib/services/agenticArticleV2Service.ts`
+- **Agent**: `/lib/agents/articleWriterV2.ts`
+- **API**: `/app/api/workflows/[id]/auto-generate-v2/`
+- **UI**: `ArticleDraftStepClean.tsx` with V2 toggle
+
+### Key Takeaways
+
+1. **Simplicity Wins**: Removing complexity (orchestrator, tools) improved quality
+2. **Trust the LLM**: Let it drive the conversation naturally
+3. **SDK Integrity**: Never break message-reasoning pairs
+4. **Content Flexibility**: Handle all SDK content formats
+5. **Database First**: TEXT columns prevent AI content truncation
+
+The V2 approach proves that true LLM orchestration - where the model drives the process through natural conversation - produces superior results compared to complex code-driven orchestration.
+
+### ArticleEndCritic: Intelligent Completion Detection
+
+#### The Problem
+The V2 writer doesn't naturally know when to stop writing - it can continue to the section limit without recognizing a proper conclusion has been reached.
+
+#### The Solution: ArticleEndCritic Pattern
+A separate critic agent that evaluates whether the article has reached its natural conclusion, using the writer's own generated outline.
+
+#### Implementation Evolution
+
+**1. Initial Approach (Failed)**
+- Tried using `<<END_OF_ARTICLE>>` marker in prompts
+- Result: AI ended articles prematurely after 2-3 sections
+- Learning: Direct instructions interfere with natural flow
+
+**2. Final Implementation**
+```typescript
+export const createArticleEndCritic = (writerPlanningResponse: string) => new Agent({
+  name: 'ArticleEndCritic',
+  model: 'o4-mini',  // Final model choice after testing
+  instructions: `You are an END-OF-ARTICLE detector.
+
+You will receive the entire draft after each new section.  
+Using your own judgment, answer **YES** only when BOTH are true:
+
+1.   The draft has covered every major section from the writer's planned outline below.
+2.   The draft ends with a paragraph or short section that clearly concludes
+     the piece— it summarises or reflects on the article's main points AND
+     provides a sense of closure (e.g. a call-to-action or a forward-looking
+     remark).
+
+If either condition is missing, reply **NO**.
+
+Return a single word: YES or NO.  Do not critique style or correctness.
+
+Here is the writer's planning response and outline:
+${writerPlanningResponse.trim()}`,
+  outputType: z.object({
+    verdict: z.enum(['YES', 'NO']).describe('Whether the article is complete')
+  }),
+});
+```
+
+**3. Dynamic Timing Based on Writer's Outline**
+```typescript
+// Create critic AFTER planning phase with writer's outline
+let planningResult = await writerRunner.run(writerAgentV2, conversationHistory, {
+  stream: true,
+  maxTurns: 1
+});
+
+// Extract planning response...
+await planningResult.finalOutput;
+
+// NOW create ArticleEndCritic with the writer's generated outline
+articleEndCritic = createArticleEndCritic(planningResponse);
+
+// Recalculate CHECK_START based on the writer's outline
+const planningLines = planningResponse.split('\n');
+const plannedSections = planningLines.filter(line => /^\d+\./.test(line.trim())).length;
+const expectedSections = Math.max(5, plannedSections);
+CHECK_START = Math.max(5, Math.floor(expectedSections * 0.6)); // Check at 60%
+```
+
+**4. Integration with Verdict Extraction**
+```typescript
+// Use ArticleEndCritic after CHECK_START sections
+if (!articleComplete && sectionCount >= CHECK_START) {
+  console.log(`🔍 Checking if article is complete (section ${sectionCount})...`);
+  
+  try {
+    // Prepare the draft so far (skip planning, include all writing)
+    const draftSoFar = writerOutputs.slice(1).join('\n\n');
+    
+    const criticRun = await writerRunner.run(articleEndCritic, [
+      { role: 'user', content: draftSoFar }
+    ]);
+    
+    const verdictResult = await criticRun.finalOutput;
+    // Extract verdict from the structured output object
+    const verdict = verdictResult?.verdict || (typeof verdictResult === 'string' ? verdictResult : 'NO');
+    
+    if (verdict === 'YES') {
+      articleComplete = true;
+      console.log(`✅ Article complete - critic confirmed after ${sectionCount} sections`);
+    }
+  } catch (error) {
+    console.error('❌ Critic evaluation failed:', error);
+    // Continue writing on critic failure - don't break the flow
+    sseUpdate(sessionId, { 
+      type: 'warning', 
+      message: 'Article completion check failed, continuing to write...' 
+    });
+  }
+}
+```
+
+#### Key Benefits
+1. **Separation of Concerns**: Writer focuses on writing, critic on evaluation
+2. **Context-Aware**: Critic sees writer's own generated outline (not initial research)
+3. **Efficient**: Uses lightweight o4-mini model for quick decisions
+4. **Graceful Failure**: Continues writing if critic fails
+5. **Dynamic Timing**: Adjusts CHECK_START based on writer's actual plan
+6. **Natural Flow**: No interference with writer's creative process
+
+#### Best Practices
+- Create critic AFTER planning phase with writer's generated outline
+- Start checking at 60% expected completion
+- Handle critic failures gracefully without breaking flow
+- Use a fast model (o4-mini) for efficiency
+- Keep critic instructions focused on structure, not style
+- Extract verdict properly from structured output
+
+#### Critical Learning
+The key insight was using the writer's own generated outline rather than the initial research outline. This ensures the critic evaluates based on what the writer actually planned to write, not what we initially thought it should write.
+
+This pattern elegantly solves the article completion detection problem without disrupting the natural flow of the V2 writer agent.
+
+### V2 Technical Implementation Details for Future Agents
+
+#### Core Implementation Pattern
+```typescript
+// 1. ALWAYS store prompts in database fields, NOT in code
+const PLANNING_PROMPT = workflowStep.inputs.planningPrompt; // From DB
+const TITLE_INTRO_PROMPT = workflowStep.inputs.titleIntroPrompt; // From DB
+const LOOPING_PROMPT = workflowStep.inputs.loopingPrompt; // From DB
+
+// 2. Single agent with EMPTY instructions
+export const writerAgentV2 = new Agent({
+  name: 'ArticleWriterV2',
+  instructions: '', // CRITICAL: Empty - all guidance from conversation
+  model: 'o3-2025-04-16',
+  tools: [fileSearch], // Only vector store, NO custom tools
+});
+
+// 3. Maintain full conversation history
+let conversationHistory = [{ role: 'user', content: `${PLANNING_PROMPT}\n\n${outline}` }];
+```
+
+#### Critical Message Handling Pattern
+```typescript
+// NEVER do this - breaks message-reasoning pairs
+messages.push({ role: 'assistant', content: response }); // ❌ WRONG
+
+// ALWAYS do this - preserves SDK integrity
+await result.finalOutput; // MUST await before accessing history
+conversationHistory = (result as any).history; // ✅ CORRECT
+```
+
+#### Content Extraction Pattern
+```typescript
+// Handle BOTH content types from SDK
+.filter((item: any) => 
+  item.type === 'text' || item.type === 'output_text' // SDK uses both
+)
+.map((item: any) => item.text || '') // Extract text field
+.join('');
+```
+
+#### ArticleEndCritic Implementation Pattern
+```typescript
+// 1. Create AFTER writer's planning phase
+let articleEndCritic = null;
+let CHECK_START = 5; // Default
+
+// After planning response received:
+articleEndCritic = createArticleEndCritic(planningResponse); // Writer's outline
+
+// 2. Factory function with writer's outline
+export const createArticleEndCritic = (writerPlanningResponse: string) => new Agent({
+  name: 'ArticleEndCritic',
+  model: 'o4-mini', // Fast model for binary decision
+  instructions: `[EXACT PROMPT WITH ${writerPlanningResponse}]`,
+  outputType: z.object({ // NOT z.enum - must be object
+    verdict: z.enum(['YES', 'NO']).describe('Whether the article is complete')
+  }),
+});
+
+// 3. Extract verdict properly
+const verdictResult = await criticRun.finalOutput;
+const verdict = verdictResult?.verdict || 'NO'; // From object property
+```
+
+#### Session Management Pattern
+```typescript
+// Database schema - ALWAYS use TEXT for AI content
+export const v2AgentSessions = pgTable('v2_agent_sessions', {
+  id: uuid('id').primaryKey(),
+  workflowId: uuid('workflow_id').notNull(),
+  version: integer('version').notNull(), // Track iterations
+  stepId: varchar('step_id', { length: 50 }).notNull(), // 'article-draft-v2'
+  status: varchar('status', { length: 50 }).notNull(), // States below
+  outline: text('outline'), // TEXT not VARCHAR
+  finalArticle: text('final_article'), // TEXT not VARCHAR
+  errorMessage: text('error_message'), // TEXT not VARCHAR
+  sessionMetadata: jsonb('session_metadata'), // Flexible data
+  // ... timestamps
+});
+
+// Status progression
+'initializing' → 'orchestrating' → 'writing' → 'completed' | 'failed'
+```
+
+#### Streaming Pattern Without Breaking SDK
+```typescript
+// Stream to frontend while preserving SDK integrity
+for await (const event of result.toStream()) {
+  if (event.type === 'raw_model_stream_event' && 
+      event.data.type === 'output_text_delta') {
+    sseUpdate(sessionId, { type: 'text', content: event.data.delta });
+  }
+}
+// THEN await finalOutput and copy history
+```
+
+#### Progress Tracking Without Known Total
+```typescript
+// Don't show confusing percentages
+const hasKnownTotal = progress?.session.totalSections && progress.session.totalSections > 0;
+
+// Display logic
+hasKnownTotal 
+  ? `${Math.round((completed / total) * 100)}% Complete`
+  : `${completed} sections completed` // Just count
+```
+
+#### Key Implementation Rules
+
+**1. Message History Management**
+- NEVER manually create assistant messages
+- ALWAYS await result.finalOutput before copying history
+- ALWAYS use (result as any).history for full SDK history
+- Message-reasoning pairs are sacred - don't break them
+
+**2. Content Handling**
+- Support both 'text' and 'output_text' types
+- Handle string OR array content formats
+- Extract planning response from first assistant message
+- Skip planning (index 0) when assembling final article
+
+**3. Critic Pattern**
+- Create critic AFTER writer generates outline
+- Pass writer's planning response, not initial research
+- Use structured output with z.object, not z.enum
+- Calculate CHECK_START dynamically from writer's outline
+- Gracefully continue on critic failure
+
+**4. Database Design**
+- ALWAYS use TEXT for AI-generated content
+- NEVER use VARCHAR for anything AI writes
+- Track version numbers for multiple attempts
+- Store complete outline and final article
+
+**5. Section Management**
+```typescript
+const maxSections = 40; // Raised from 20
+const CHECK_START = Math.max(5, Math.floor(expectedSections * 0.6));
+const writerOutputs: string[] = []; // Track all outputs
+const finalArticle = writerOutputs.slice(1).join('\n\n'); // Skip planning
+```
+
+#### Common Pitfalls to Avoid
+1. **Don't add instructions to prompts** - Breaks natural flow
+2. **Don't use END_OF_ARTICLE markers** - Causes premature ending
+3. **Don't break message-reasoning pairs** - Causes 400 errors
+4. **Don't assume content type** - SDK varies output format
+5. **Don't use initial outline for critic** - Use writer's interpretation
+
+#### API Endpoint Pattern
+```typescript
+// POST /api/workflows/[id]/auto-generate-v2
+const { outline } = await req.json();
+const sessionId = await agenticArticleV2Service.startSession(workflowId, outline);
+return Response.json({ success: true, sessionId });
+
+// GET /api/workflows/[id]/auto-generate-v2/stream
+res.writeHead(200, {
+  'Content-Type': 'text/event-stream',
+  'Cache-Control': 'no-cache',
+  'Connection': 'keep-alive',
+});
+addSSEConnection(sessionId, res);
+agenticArticleV2Service.performArticleGeneration(sessionId);
+```
+
+This technical pattern creates natural LLM orchestration by maintaining full conversation context and letting the model drive the process through database prompts.
+
+## Contact
+Created for OutreachLabs by Claude with Ajay
+Repository: https://github.com/ajaypag/guest-post-workflow

--- a/docs/db/SCHEMA_RULES.md
+++ b/docs/db/SCHEMA_RULES.md
@@ -1,0 +1,99 @@
+# Database Schema Rules
+
+> **Why**: Prevent silent failures from VARCHAR size limits  
+> **Use when**: Creating tables for AI-generated content  
+> **Outcome**: No more "database error" debugging sessions
+
+## The Hidden Killer: VARCHAR Limits
+
+AI agents generate long, descriptive content that exceeds typical VARCHAR sizes.
+
+### ❌ What Goes Wrong
+```sql
+-- Agent generates: "engagement-focused-with-semantic-clarity-balanced-approach"
+polish_approach VARCHAR(100) -- FAILS SILENTLY!
+```
+
+Error: Vague "Failed query" with no size hint.
+
+### ✅ Safe Column Sizes
+
+| Content Type | Safe Choice | Why |
+|--------------|-------------|-----|
+| AI descriptions | `VARCHAR(255)` or `TEXT` | Agents write long descriptions |
+| Titles | `VARCHAR(500)` | Special chars count double |
+| Long content | `TEXT` | No size limits |
+| Status/types | `VARCHAR(50)` | Fixed values are short |
+
+## Creating Agent Tables
+
+### ❌ Wrong Pattern
+```sql
+CREATE TABLE agent_outputs (
+  approach VARCHAR(100),      -- TOO SMALL!
+  description VARCHAR(100),   -- TOO SMALL!
+  title VARCHAR(255)         -- RISKY!
+);
+```
+
+### ✅ Correct Pattern
+```sql
+CREATE TABLE agent_outputs (
+  approach VARCHAR(255),      -- Safe for descriptions
+  description TEXT,          -- Unlimited length
+  title VARCHAR(500),        -- Extra safe
+  status VARCHAR(50),        -- OK for fixed values
+  content TEXT,              -- Always TEXT for AI content
+  error_message TEXT         -- Errors can be long
+);
+```
+
+## Quick Diagnosis
+
+Visit `/admin/column-check` to see:
+- All VARCHAR columns and sizes
+- "❌ TOO SMALL" warnings
+- One-click fix buttons
+
+## Migration Pattern
+
+```sql
+-- Fix existing columns
+ALTER TABLE your_table 
+  ALTER COLUMN description TYPE TEXT,
+  ALTER COLUMN approach TYPE VARCHAR(255),
+  ALTER COLUMN title TYPE VARCHAR(500);
+```
+
+## Golden Rules
+
+1. **AI writes long**: Default to `TEXT`
+2. **Descriptions**: Minimum `VARCHAR(255)`
+3. **Titles**: Use `VARCHAR(500)`
+4. **When in doubt**: Use `TEXT`
+5. **Test with real AI output**: Not "test"
+
+## Common Failures
+
+| Column | Failed Value | Fix |
+|--------|--------------|-----|
+| `approach VARCHAR(100)` | "engagement-focused-with-semantic-clarity" | `VARCHAR(255)` |
+| `title VARCHAR(255)` | Long title with emojis | `VARCHAR(500)` |
+| `content VARCHAR(1000)` | Multi-paragraph text | `TEXT` |
+
+## Testing New Tables
+
+1. Create table with proposed schema
+2. Generate real AI content
+3. Try to insert
+4. If fails, check `/admin/varchar-limits`
+5. Fix and retry
+
+## Reference
+
+See working examples:
+- `v2_agent_sessions` table
+- `semantic_audit_sections` table
+- `formatting_qa_checks` table
+
+All use `TEXT` for AI-generated content.

--- a/docs/migrations/CHECKLIST.md
+++ b/docs/migrations/CHECKLIST.md
@@ -1,0 +1,164 @@
+# Database Migration Checklist
+
+> **Why**: Ensure new features work without debugging sessions  
+> **Use when**: Adding tables for agentic features  
+> **Outcome**: Smooth deployment with proper admin tools
+
+## Pre-Migration Checklist
+
+- [ ] Design schema with TEXT for AI content
+- [ ] Plan admin UI pages
+- [ ] Create diagnostic endpoints
+- [ ] Test with real AI output
+
+## Migration Steps
+
+### 1. Create Schema File
+```typescript
+// lib/db/schema/yourFeature.ts
+export const yourFeatureSessions = pgTable('your_feature_sessions', {
+  id: uuid('id').primaryKey(),
+  workflowId: uuid('workflow_id').notNull(),
+  status: varchar('status', { length: 50 }).notNull(),
+  
+  // AI content - always TEXT
+  inputs: text('inputs'),
+  outputs: text('outputs'), 
+  errorMessage: text('error_message'),
+  
+  // Metadata
+  sessionMetadata: jsonb('session_metadata'),
+  createdAt: timestamp('created_at').defaultNow(),
+  updatedAt: timestamp('updated_at').defaultNow()
+});
+```
+
+### 2. Generate Migration
+```bash
+npm run db:generate
+# Creates SQL in drizzle/migrations/
+```
+
+### 3. Create Admin UI
+
+#### Migration Management
+```typescript
+// app/admin/database-migration/page.tsx
+<MigrationSection
+  title="Your Feature"
+  checkEndpoint="/api/admin/check-your-feature"
+  createEndpoint="/api/admin/migrate-your-feature"
+  removeEndpoint="/api/admin/remove-your-feature"
+/>
+```
+
+#### Feature Diagnostics  
+```typescript
+// app/admin/fix-your-feature/page.tsx
+- Check tables exist
+- Verify column sizes
+- Test data insertion
+- Auto-fix buttons
+```
+
+### 4. Create API Endpoints
+
+```typescript
+// app/api/admin/migrate-your-feature/route.ts
+export async function GET() {
+  // Check if tables exist
+}
+
+export async function POST() {
+  // Create tables
+}
+
+export async function DELETE() {
+  // Drop tables (dev only)
+}
+```
+
+### 5. Test Migration Flow
+
+1. Visit `/admin/database-migration`
+2. Click "Check" - should show missing
+3. Click "Create" - tables created
+4. Click "Check" - should show exists
+5. Test feature end-to-end
+
+## Post-Migration Checklist
+
+- [ ] Tables created in production
+- [ ] Admin UI accessible
+- [ ] Diagnostics working
+- [ ] Feature saves data correctly
+- [ ] No VARCHAR size errors
+
+## Common Issues
+
+### Tables Not Creating
+- Check migration file exists
+- Verify SQL syntax
+- Look for connection errors
+
+### Admin UI Not Working
+- Endpoints returning 404?
+- Check route.ts exports
+- Verify API paths match
+
+### Data Not Saving
+- Check column names match code
+- Verify NOT NULL constraints
+- Test with shorter data
+
+## Required Admin Pages
+
+Every feature needs:
+1. Section in `/admin/database-migration`
+2. Dedicated `/admin/fix-[feature]` page
+3. Inclusion in `/admin/diagnostics`
+4. Column check in `/admin/varchar-limits`
+
+## SQL Patterns
+
+### Safe Defaults
+```sql
+-- Status columns
+status VARCHAR(50) NOT NULL DEFAULT 'pending'
+
+-- Timestamps
+created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+
+-- AI content
+content TEXT -- Never VARCHAR for AI
+```
+
+### Indexes
+```sql
+-- Foreign keys
+CREATE INDEX idx_workflow_id ON your_table(workflow_id);
+
+-- Status queries
+CREATE INDEX idx_status ON your_table(status);
+```
+
+## Rollback Plan
+
+```sql
+-- Keep rollback ready
+DROP TABLE IF EXISTS your_feature_sessions CASCADE;
+DROP TABLE IF EXISTS your_feature_items CASCADE;
+```
+
+## Success Criteria
+
+- [ ] Feature works end-to-end
+- [ ] No "database error" messages
+- [ ] Admin can diagnose issues
+- [ ] Migration is repeatable
+
+## Next Steps
+
+- Document in DEVELOPER_GUIDE.md
+- Monitor for VARCHAR issues
+- Add to diagnostic suite

--- a/docs/releases/CHANGELOG.md
+++ b/docs/releases/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+## v1.1.0 (2025-01-19) - Documentation Refactor
+- Restructured documentation into focused guides
+- Created job-specific documentation files
+- Added diagnostic tools documentation
+- Improved README to under 100 lines
+
+## v1.0.5 (2025-01-19) - V2 Article Generation
+- Added V2 LLM orchestration for article generation
+- Implemented ArticleEndCritic for completion detection
+- Fixed message-reasoning pair integrity
+- Increased section limit to 40
+
+## v1.0.4 (2025-01-15) - Semantic Audit V2
+- Implemented V2 semantic audit with auto-save
+- Fixed force-save event handling
+- Added debugging for auto-save issues
+- Improved section formatting when merging
+
+## v1.0.3 (2025-01-09) - Agent Retry Logic
+- Added retry pattern for agent text responses
+- Fixed conversation history pollution
+- Implemented agentUtils helper functions
+
+## v1.0.2 (2025-01-05) - Formatting QA
+- Added formatting QA agentic feature
+- Created comprehensive diagnostics system
+- Implemented VARCHAR limit checking
+- Added admin UI requirements
+
+## v1.0.1 (2025-01-03) - Teams Integration
+- Added Teams Workspace button to step components
+- Updated ArticleDraftStepClean, ContentAuditStepClean, FinalPolishStepClean
+
+## v1.0.0 (2025-01-02) - Production Release
+- First stable production version
+- Complete 16-step workflow system
+- Multi-user PostgreSQL support
+- Client and target page management
+- Multi-account OpenAI integration

--- a/docs/setup/COOLIFY_DEPLOY.md
+++ b/docs/setup/COOLIFY_DEPLOY.md
@@ -1,0 +1,126 @@
+# Coolify Deployment Guide
+
+> **Why**: Deploy to production on Coolify v4  
+> **Use when**: Setting up new environment or updating deployment  
+> **Outcome**: Live production app with PostgreSQL
+
+## Pre-Deployment Checklist
+
+- [ ] GitHub repository connected to Coolify
+- [ ] PostgreSQL database created in Coolify
+- [ ] Domain configured (optional)
+- [ ] Environment variables ready
+
+## Deployment Steps
+
+### 1. Create PostgreSQL Database (2 min)
+
+In Coolify dashboard:
+1. **Services** → **Add Service** → **PostgreSQL**
+2. Note the internal connection details
+3. **Important**: Use internal URL format
+
+### 2. Add Application (3 min)
+
+1. **Projects** → **Add Resource** → **Public Repository**
+2. Repository: `https://github.com/ajaypag/guest-post-workflow`
+3. Build Pack: **Next.js**
+4. Branch: `main` or `semantic-audit-v2`
+
+### 3. Configure Environment (2 min)
+
+Add these variables in Coolify:
+
+```env
+# Required
+DATABASE_URL=postgresql://postgres:password@postgres:5432/guest_post_workflow?sslmode=disable
+NEXTAUTH_SECRET=generate-strong-secret-here
+NEXTAUTH_URL=https://your-domain.com
+
+# Optional AI Features
+OPENAI_API_KEY=sk-...
+OPENAI_API_KEY_BACKUP=sk-...
+VECTOR_STORE_ID=vs_...
+AGENT_TIMEOUT_MS=300000
+```
+
+**Critical**: 
+- Use internal service names (e.g., `postgres` not `localhost`)
+- Set `sslmode=disable` for internal connections
+- Generate strong NEXTAUTH_SECRET: `openssl rand -base64 32`
+
+### 4. Deploy (5 min)
+
+1. Click **Deploy**
+2. Monitor build logs
+3. Wait for "Deployment successful"
+
+### 5. Verify Deployment
+
+1. Visit your domain
+2. Login: `admin@example.com` / `admin123`
+3. Check `/database-checker` for system health
+
+## Production Configuration
+
+### Resource Limits
+```yaml
+# Recommended minimums
+CPU: 1 core
+Memory: 1GB
+Storage: 10GB
+```
+
+### Health Checks
+Configure in Coolify:
+- Path: `/api/health`
+- Interval: 30s
+- Timeout: 10s
+
+### Backup Strategy
+1. Enable automated PostgreSQL backups
+2. Set retention: 7 days minimum
+3. Test restore procedure monthly
+
+## Troubleshooting
+
+### Build Failures
+```bash
+# Check build logs in Coolify
+# Common fix: Clear build cache
+```
+
+### Database Connection Issues
+- Verify internal service name
+- Check PostgreSQL is running
+- Confirm `sslmode=disable`
+
+### 502 Bad Gateway
+- Check application logs
+- Verify environment variables
+- Ensure database migrations ran
+
+## Post-Deployment
+
+### First Time Setup
+1. Change admin password immediately
+2. Create production users
+3. Configure client accounts
+
+### Monitoring
+- Set up uptime monitoring
+- Configure error alerts
+- Monitor database size
+
+### Updates
+1. Push to GitHub
+2. Coolify auto-deploys (if enabled)
+3. Or manually trigger deployment
+
+## Security Checklist
+
+- [ ] Change default admin password
+- [ ] Use strong NEXTAUTH_SECRET
+- [ ] Enable HTTPS (Coolify handles this)
+- [ ] Restrict database access
+- [ ] Regular security updates

--- a/docs/setup/LOCAL_DEV.md
+++ b/docs/setup/LOCAL_DEV.md
@@ -1,0 +1,109 @@
+# Local Development Setup
+
+> **Why**: Get the app running locally in < 10 minutes  
+> **Use when**: First time setup or troubleshooting local issues  
+> **Outcome**: Working development environment with hot reload
+
+## Prerequisites Checklist
+
+- [ ] Node.js 18+ installed (`node --version`)
+- [ ] PostgreSQL installed and running
+- [ ] Git configured
+- [ ] Code editor (VS Code recommended)
+
+## Step-by-Step Setup
+
+### 1. Clone and Install (2 min)
+
+```bash
+git clone https://github.com/ajaypag/guest-post-workflow.git
+cd guest-post-workflow
+npm install
+```
+
+### 2. Database Setup (3 min)
+
+Create a PostgreSQL database:
+```sql
+CREATE DATABASE guest_post_workflow;
+```
+
+### 3. Environment Configuration (2 min)
+
+Create `.env.local` file:
+```env
+DATABASE_URL=postgresql://postgres:password@localhost:5432/guest_post_workflow?sslmode=disable
+NEXTAUTH_SECRET=dev-secret-key-change-in-production
+NEXTAUTH_URL=http://localhost:3000
+```
+
+Optional AI features:
+```env
+OPENAI_API_KEY=sk-...
+VECTOR_STORE_ID=vs_...
+```
+
+### 4. Start Development (1 min)
+
+```bash
+npm run dev
+```
+
+Visit http://localhost:3000
+
+**Default login**: `admin@example.com` / `admin123`
+
+## Common Issues & Fixes
+
+### Database Connection Failed
+```bash
+# Check PostgreSQL is running
+pg_isready
+
+# Verify connection string
+psql postgresql://postgres:password@localhost:5432/guest_post_workflow
+```
+
+### Port Already in Use
+```bash
+# Use different port
+PORT=3001 npm run dev
+```
+
+### Module Not Found
+```bash
+# Clear cache and reinstall
+rm -rf node_modules package-lock.json
+npm install
+```
+
+## Development Commands
+
+| Command | Purpose |
+|---------|---------|
+| `npm run dev` | Start with hot reload |
+| `npm run build` | Test production build |
+| `npm run db:studio` | Browse database GUI |
+| `npm run lint` | Check code style |
+| `npm run db:generate` | Create migrations |
+
+## Database Tools
+
+Access Drizzle Studio:
+```bash
+npm run db:studio
+# Opens http://localhost:4983
+```
+
+## Testing Workflows
+
+1. Create a test client
+2. Start a new workflow
+3. Use GPT links for each step
+4. Check auto-save works
+
+## Next Steps
+
+- Read [Building Agents](../agents/BUILDING_BLOCKS.md) to add AI features
+- Check [Database Rules](../db/SCHEMA_RULES.md) before schema changes
+- See [Diagnostics](../admin/DIAGNOSTICS.md) for debugging


### PR DESCRIPTION
- Reduced README.md from 185 to 65 lines for quick start focus
- Created organized docs/ structure with job-specific guides:
  - setup/ - Local dev and Coolify deployment
  - agents/ - Building blocks, retry pattern, V2 pattern
  - db/ - Schema rules and VARCHAR limits
  - admin/ - Diagnostics guide
  - migrations/ - Database migration checklist
  - architecture/ - Component patterns
  - releases/ - Changelog
- Archived original CLAUDE.md to docs/archive/
- Added "Why/When/Outcome" headers to each guide
- Replaced walls of text with tables and checklists
- Created central DEVELOPER_GUIDE.md index

This makes documentation findable in 90 seconds instead of endless scrolling.

🤖 Generated with [Claude Code](https://claude.ai/code)