### PR TITLE
fix: Fix database column naming issue in diagnostic queries

### DIFF
--- a/app/api/admin/check-v2-fields/route.ts
+++ b/app/api/admin/check-v2-fields/route.ts
@@ -7,11 +7,14 @@ export async function POST(request: NextRequest) {
   try {
     const { workflowId } = await request.json();
 
-    // Get all workflow steps
-    const steps = await db.query.workflowSteps.findMany({
-      where: eq(workflowSteps.workflowId, workflowId),
-      orderBy: workflowSteps.stepNumber
-    });
+    // Get all workflow steps - use select syntax to avoid column naming issues  
+    const steps = await db
+      .select()
+      .from(workflowSteps)
+      .where(eq(workflowSteps.workflowId, workflowId));
+    
+    // Sort by stepNumber in memory
+    steps.sort((a, b) => a.stepNumber - b.stepNumber);
 
     const fieldAnalysis = {
       semanticSeoStep: null as any,

--- a/app/api/admin/diagnose-autosave/route.ts
+++ b/app/api/admin/diagnose-autosave/route.ts
@@ -16,11 +16,14 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Workflow not found' }, { status: 404 });
     }
 
-    // 2. Get workflow steps
-    const steps = await db.query.workflowSteps.findMany({
-      where: eq(workflowSteps.workflowId, workflowId),
-      orderBy: workflowSteps.stepNumber
-    });
+    // 2. Get workflow steps - use select syntax to avoid column naming issues
+    const steps = await db
+      .select()
+      .from(workflowSteps)
+      .where(eq(workflowSteps.workflowId, workflowId));
+    
+    // Sort by stepNumber in memory
+    steps.sort((a, b) => a.stepNumber - b.stepNumber);
 
     // 3. Get V2 sessions
     const v2Sessions = await db.query.v2AgentSessions.findMany({


### PR DESCRIPTION
- Changed from db.query syntax to db.select syntax to avoid column naming errors
- Sort workflow steps by stepNumber in memory after query
- Fixes 'column step_number does not exist' error
- Both diagnose-autosave and check-v2-fields endpoints now work properly

🤖 Generated with Claude Code