### PR TITLE
refactor: Remove excessive navigation warnings now that auto-save works

### DIFF
--- a/components/StepForm.tsx
+++ b/components/StepForm.tsx
@@ -159,12 +159,12 @@ export default function StepForm({ step, stepIndex, workflow, onSave, onWorkflow
     }
   }, [workflow.id, localOutputs, handleSave]);
 
-  // Initialize navigation guard
-  const { generateHash } = useNavigationGuard({
-    activeOperations,
-    onSaveRequest: performVerifiedSave,
-    workflowId: workflow.id
-  });
+  // Navigation guard disabled - auto-save handles persistence
+  // const { generateHash } = useNavigationGuard({
+  //   activeOperations,
+  //   onSaveRequest: performVerifiedSave,
+  //   workflowId: workflow.id
+  // });
 
   useEffect(() => {
     console.log('Step data changed, updating local state:', { inputs: step.inputs, outputs: step.outputs });
@@ -385,9 +385,7 @@ export default function StepForm({ step, stepIndex, workflow, onSave, onWorkflow
           onAgentStateChange={(agentRunning) => {
             setActiveOperations(prev => ({ ...prev, agentRunning }));
           }}
-          onUnsavedContentChange={(hasUnsavedContent) => {
-            setActiveOperations(prev => ({ ...prev, hasUnsavedChanges: hasUnsavedContent }));
-          }}
+          // onUnsavedContentChange not needed - auto-save handles persistence
         />
 
         {/* Outputs Section */}

--- a/components/steps/ArticleDraftStepClean.tsx
+++ b/components/steps/ArticleDraftStepClean.tsx
@@ -41,7 +41,6 @@ export const ArticleDraftStepClean = ({ step, workflow, onChange, onAgentStateCh
 
   // Track if an AI agent is running
   const [agentRunning, setAgentRunning] = useState(false);
-  const [hasUnsavedContent, setHasUnsavedContent] = useState(false);
   
   // Mock mode for testing
   const [mockMode, setMockMode] = useState(false);
@@ -80,18 +79,10 @@ ${outlineContent || '((((Complete Step 3: Deep Research first to get outline con
       }
     }
 
-    // Check for unsaved content in current tab
-    if (hasUnsavedContent) {
-      const message = `You have unsaved content in the ${activeTab} tab. Switching tabs may lose this content. Continue?`;
-      if (!window.confirm(message)) {
-        return;
-      }
-    }
+    // No need to check for unsaved content - auto-save handles it
 
     // Clear any running agent state
     setAgentRunning(false);
-    setHasUnsavedContent(false);
-    onUnsavedContentChange?.(false);
     
     // Switch tab
     setActiveTab(newTab);
@@ -646,9 +637,7 @@ ${outlineContent || '((((Complete Step 3: Deep Research first to get outline con
                     };
                     console.log('[ArticleDraftStepClean] Calling onChange with updated outputs');
                     onChange(updatedOutputs);
-                    setHasUnsavedContent(true);
-                    onUnsavedContentChange?.(true);
-                    console.log('[ArticleDraftStepClean] onChange completed, hasUnsavedContent set to true - user must manually save');
+                    console.log('[ArticleDraftStepClean] onChange completed - auto-save will handle persistence');
                   }}
                   onGeneratingStateChange={(isGenerating) => {
                     setAgentRunning(isGenerating);


### PR DESCRIPTION
With auto-save working properly, the aggressive navigation warnings are no longer needed and become annoying. Streamlined to only keep:

- Agent running warnings (prevent interrupting AI generation)

Removed:
- Tab switching warnings (auto-save handles persistence)
- Browser close/reload warnings (didn't work anyway)
- Navigation step warnings (auto-save handles persistence)
- Forced unsaved content flags after AI generation

The workflow is now much more user-friendly while still protecting against actual data loss scenarios.

🤖 Generated with [Claude Code](https://claude.ai/code)