### PR TITLE
feat: Implement V2 Polish/Finalize agent with two-prompt loop pattern

### DIFF
--- a/app/api/workflows/[id]/final-polish-v2/start/route.ts
+++ b/app/api/workflows/[id]/final-polish-v2/start/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { agenticFinalPolishV2Service } from '@/lib/services/agenticFinalPolishV2Service';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const workflowId = params.id;
+    console.log(`📝 Starting V2 polish session for workflow ${workflowId}`);
+    
+    // Start the session
+    const sessionId = await agenticFinalPolishV2Service.startSession(workflowId);
+    
+    // Start the polish process in the background
+    agenticFinalPolishV2Service.performPolish(sessionId).catch(error => {
+      console.error('Background polish process failed:', error);
+    });
+    
+    return NextResponse.json({ 
+      sessionId,
+      message: 'V2 polish session started successfully' 
+    });
+  } catch (error: any) {
+    console.error('Failed to start V2 polish session:', error);
+    return NextResponse.json(
+      { error: error.message || 'Failed to start polish session' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/workflows/[id]/final-polish-v2/stream/route.ts
+++ b/app/api/workflows/[id]/final-polish-v2/stream/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { agenticFinalPolishV2Service, addSSEConnection, removeSSEConnection } from '@/lib/services/agenticFinalPolishV2Service';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const sessionId = request.nextUrl.searchParams.get('sessionId');
+  
+  if (!sessionId) {
+    return NextResponse.json({ error: 'Session ID required' }, { status: 400 });
+  }
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      const encoder = new TextEncoder();
+      
+      // Helper to send SSE messages
+      const sendMessage = (data: any) => {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+      };
+
+      // Register this connection
+      const res = {
+        write: (chunk: string) => {
+          controller.enqueue(encoder.encode(chunk));
+        }
+      };
+      
+      addSSEConnection(sessionId, res);
+
+      // Send initial connection message
+      sendMessage({ type: 'connected', sessionId });
+
+      // Check session status periodically
+      const statusInterval = setInterval(async () => {
+        try {
+          const progress = await agenticFinalPolishV2Service.getSessionProgress(sessionId);
+          
+          if (progress?.session?.status === 'completed') {
+            clearInterval(statusInterval);
+            removeSSEConnection(sessionId);
+            controller.close();
+          } else if (progress?.session?.status === 'failed') {
+            clearInterval(statusInterval);
+            removeSSEConnection(sessionId);
+            sendMessage({ 
+              type: 'error', 
+              error: progress.session.errorMessage || 'Polish process failed' 
+            });
+            controller.close();
+          }
+        } catch (error) {
+          console.error('Error checking session status:', error);
+        }
+      }, 2000);
+
+      // Cleanup on client disconnect
+      request.signal.addEventListener('abort', () => {
+        clearInterval(statusInterval);
+        removeSSEConnection(sessionId);
+        controller.close();
+      });
+    }
+  });
+
+  return new NextResponse(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+    },
+  });
+}

--- a/components/steps/FinalPolishStepClean.tsx
+++ b/components/steps/FinalPolishStepClean.tsx
@@ -8,6 +8,7 @@ import { TutorialVideo } from '../ui/TutorialVideo';
 import { ChatInterface } from '../ui/ChatInterface';
 import { SplitPromptButton } from '../ui/SplitPromptButton';
 import { AgenticFinalPolisher } from '../ui/AgenticFinalPolisher';
+import { AgenticFinalPolisherV2 } from '../ui/AgenticFinalPolisherV2';
 import { MarkdownPreview } from '../ui/MarkdownPreview';
 import { ExternalLink, ChevronDown, ChevronRight, Sparkles, CheckCircle, AlertCircle, Target, RefreshCw, FileText } from 'lucide-react';
 
@@ -25,7 +26,7 @@ export const FinalPolishStepClean = ({ step, workflow, onChange }: FinalPolishSt
   });
 
   // Tab system state
-  const [activeTab, setActiveTab] = useState<'chatgpt' | 'builtin' | 'agentic'>('agentic');
+  const [activeTab, setActiveTab] = useState<'chatgpt' | 'builtin' | 'agentic' | 'agenticv2'>('agenticv2');
 
   // Chat state management
   const [conversation, setConversation] = useState<any[]>([]);
@@ -181,6 +182,19 @@ Review one of my project files for my brand guide and the Semantic SEO writing t
       <div className="bg-white border border-gray-200 rounded-xl overflow-hidden">
         <div className="flex border-b border-gray-200">
           <button
+            onClick={() => setActiveTab('agenticv2')}
+            className={`flex-1 px-6 py-4 text-sm font-medium transition-colors ${
+              activeTab === 'agenticv2'
+                ? 'bg-purple-50 text-purple-700 border-b-2 border-purple-500'
+                : 'text-gray-500 hover:text-gray-700 hover:bg-gray-50'
+            }`}
+          >
+            <div className="flex items-center justify-center space-x-2">
+              <Sparkles className="w-4 h-4" />
+              <span>Agentic V2</span>
+            </div>
+          </button>
+          <button
             onClick={() => setActiveTab('agentic')}
             className={`flex-1 px-6 py-4 text-sm font-medium transition-colors ${
               activeTab === 'agentic'
@@ -190,7 +204,7 @@ Review one of my project files for my brand guide and the Semantic SEO writing t
           >
             <div className="flex items-center justify-center space-x-2">
               <Sparkles className="w-4 h-4" />
-              <span>Agentic Polish</span>
+              <span>Agentic V1</span>
             </div>
           </button>
           <button
@@ -216,7 +230,95 @@ Review one of my project files for my brand guide and the Semantic SEO writing t
         </div>
 
         <div className="p-6">
-          {activeTab === 'chatgpt' ? (
+          {activeTab === 'agenticv2' ? (
+            <div className="space-y-6">
+              {/* Agentic V2 Polish Interface */}
+              <div className="bg-purple-50 border border-purple-200 rounded-lg p-4">
+                <h3 className="font-medium text-purple-900 mb-2 flex items-center space-x-2">
+                  <Sparkles className="w-5 h-5" />
+                  <span>Agentic Polish V2 - Two-Prompt Loop</span>
+                </h3>
+                <p className="text-sm text-purple-800 mb-3">
+                  Fully automated polish using the same two-prompt loop pattern as ChatGPT tab:
+                </p>
+                <ul className="text-sm text-purple-700 space-y-1 list-disc list-inside">
+                  <li><strong>Kickoff</strong> - Reviews first section for brand guide compliance</li>
+                  <li><strong>Proceed → Cleanup Loop</strong> - For each section: analyze then refine</li>
+                  <li><strong>Brand alignment</strong> - Balances engagement with semantic clarity</li>
+                  <li><strong>Automatic progression</strong> - No manual copying between prompts</li>
+                </ul>
+                <div className="mt-3 p-3 bg-purple-100 rounded border border-purple-300">
+                  <p className="text-xs text-purple-800 font-medium">
+                    🚀 V2 Pattern: LLM-driven orchestration with natural conversation flow
+                  </p>
+                </div>
+              </div>
+
+              {/* Dependency check */}
+              {seoOptimizedArticle ? (
+                <div className="bg-green-50 border border-green-200 rounded-lg p-4">
+                  <div className="flex items-center">
+                    <CheckCircle className="w-5 h-5 text-green-600 mr-2" />
+                    <p className="text-sm text-green-800">Using SEO-optimized article from Step 5</p>
+                  </div>
+                </div>
+              ) : originalArticle ? (
+                <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
+                  <div className="flex items-center">
+                    <AlertCircle className="w-5 h-5 text-yellow-500 mr-2" />
+                    <p className="text-sm text-yellow-800">Using original draft from Step 4 (complete Step 5 for SEO-optimized version)</p>
+                  </div>
+                </div>
+              ) : (
+                <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+                  <div className="flex items-center">
+                    <AlertCircle className="w-5 h-5 text-red-500 mr-2" />
+                    <p className="text-sm text-red-800">Complete Step 5 (Semantic SEO) first to get the optimized article for polishing</p>
+                  </div>
+                </div>
+              )}
+
+              {/* Agentic Final Polisher V2 Component */}
+              {fullArticle && (
+                <AgenticFinalPolisherV2 
+                  workflowId={workflow.id}
+                  onComplete={(polishedArticle) => {
+                    onChange({ 
+                      ...step.outputs, 
+                      finalArticle: polishedArticle,
+                      polishProgress: '100',
+                      tab3Created: 'yes',
+                      agentV2Generated: true
+                    });
+                  }}
+                />
+              )}
+
+              {/* Results Section */}
+              {step.outputs.finalArticle && step.outputs.agentV2Generated && (
+                <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
+                  <div className="bg-green-50 border-l-4 border-green-400 p-4 mb-4 rounded-r-lg">
+                    <h4 className="font-medium text-green-800 mb-2">✅ V2 Polish Complete</h4>
+                    <p className="text-sm text-green-700">The AI has successfully applied the two-prompt loop pattern to balance brand voice with semantic directness.</p>
+                  </div>
+
+                  <SavedField
+                    label="Final Polished Article"
+                    value={step.outputs.finalArticle || ''}
+                    placeholder="The polished article will appear here automatically..."
+                    onChange={(value) => onChange({ ...step.outputs, finalArticle: value })}
+                    isTextarea={true}
+                    height="h-64"
+                  />
+                  
+                  <MarkdownPreview 
+                    content={step.outputs.finalArticle}
+                    className="mt-4"
+                  />
+                </div>
+              )}
+            </div>
+          ) : activeTab === 'chatgpt' ? (
             <div className="space-y-6">
               {/* Original ChatGPT.com workflow */}
       

--- a/components/ui/AgenticFinalPolisherV2.tsx
+++ b/components/ui/AgenticFinalPolisherV2.tsx
@@ -1,0 +1,268 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { Sparkles, Loader2, CheckCircle, AlertTriangle, RefreshCw, FileText } from 'lucide-react';
+
+interface AgenticFinalPolisherV2Props {
+  workflowId: string;
+  onComplete?: (polishedArticle: string) => void;
+}
+
+interface PolishProgress {
+  type: string;
+  status?: string;
+  message?: string;
+  phase?: string;
+  content?: string;
+  sectionNumber?: number;
+  finalPolishedArticle?: string;
+  wordCount?: number;
+  totalSections?: number;
+  error?: string;
+}
+
+export const AgenticFinalPolisherV2: React.FC<AgenticFinalPolisherV2Props> = ({
+  workflowId,
+  onComplete
+}) => {
+  const [isRunning, setIsRunning] = useState(false);
+  const [progress, setProgress] = useState<PolishProgress | null>(null);
+  const [finalArticle, setFinalArticle] = useState<string>('');
+  const [error, setError] = useState<string>('');
+  const [sessionId, setSessionId] = useState<string>('');
+  const [completedSections, setCompletedSections] = useState(0);
+  const [currentPhase, setCurrentPhase] = useState<string>('');
+
+  // Start the V2 polish process
+  const startPolish = async () => {
+    try {
+      setIsRunning(true);
+      setError('');
+      setProgress(null);
+      setFinalArticle('');
+      setCompletedSections(0);
+      setCurrentPhase('');
+
+      console.log('🎨 Starting V2 polish process...');
+
+      // Start the polish session
+      const response = await fetch(`/api/workflows/${workflowId}/final-polish-v2/start`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' }
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to start V2 polish');
+      }
+
+      setSessionId(data.sessionId);
+      console.log('✅ V2 Polish session started:', data.sessionId);
+
+      // Start listening to SSE stream
+      startSSEStream(data.sessionId);
+
+    } catch (error: any) {
+      console.error('❌ Error starting V2 polish:', error);
+      setError(error.message || 'Failed to start polish process');
+      setIsRunning(false);
+    }
+  };
+
+  // Start SSE stream for real-time updates
+  const startSSEStream = (sessionId: string) => {
+    const eventSource = new EventSource(`/api/workflows/${workflowId}/final-polish-v2/stream?sessionId=${sessionId}`);
+    
+    eventSource.onmessage = (event) => {
+      try {
+        const data: PolishProgress = JSON.parse(event.data);
+        console.log('📡 V2 Polish SSE update:', data);
+        
+        setProgress(data);
+        handleProgressUpdate(data);
+      } catch (error) {
+        console.error('Error parsing SSE data:', error);
+      }
+    };
+
+    eventSource.onerror = (error) => {
+      console.error('❌ SSE connection error:', error);
+      eventSource.close();
+      setIsRunning(false);
+    };
+
+    // Cleanup on unmount
+    return () => {
+      eventSource.close();
+    };
+  };
+
+  // Handle different types of progress updates
+  const handleProgressUpdate = (data: PolishProgress) => {
+    switch (data.type) {
+      case 'connected':
+        console.log('🔗 Connected to V2 polish stream');
+        break;
+
+      case 'status':
+        console.log(`📊 Status: ${data.status} - ${data.message}`);
+        break;
+
+      case 'phase':
+        console.log(`🔄 Phase: ${data.phase} - ${data.message}`);
+        setCurrentPhase(data.message || '');
+        break;
+
+      case 'text':
+        // Text streaming - could show partial output if desired
+        break;
+
+      case 'section_completed':
+        console.log(`✅ Section ${data.sectionNumber} completed`);
+        setCompletedSections(data.sectionNumber || 0);
+        break;
+
+      case 'completed':
+        console.log('🎉 V2 Polish completed!');
+        setFinalArticle(data.finalPolishedArticle || '');
+        setIsRunning(false);
+        
+        if (onComplete && data.finalPolishedArticle) {
+          onComplete(data.finalPolishedArticle);
+        }
+        break;
+
+      case 'error':
+        console.error('❌ Polish error:', data.error);
+        setError(data.error || 'An error occurred during polish');
+        setIsRunning(false);
+        break;
+    }
+  };
+
+  return (
+    <div className="bg-gradient-to-r from-purple-50 to-blue-50 border border-purple-200 rounded-lg p-6">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center space-x-3">
+          <div className="bg-purple-600 rounded-full p-2">
+            <Sparkles className="w-5 h-5 text-white" />
+          </div>
+          <div>
+            <h3 className="font-semibold text-purple-900">Agentic Polish V2</h3>
+            <p className="text-sm text-purple-700">
+              Two-prompt loop pattern for brand alignment
+            </p>
+          </div>
+        </div>
+        
+        {!isRunning && !finalArticle && (
+          <button
+            onClick={startPolish}
+            className="px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors flex items-center space-x-2"
+          >
+            <RefreshCw className="w-4 h-4" />
+            <span>Start Polish V2</span>
+          </button>
+        )}
+      </div>
+
+      {/* Error Display */}
+      {error && (
+        <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg">
+          <div className="flex items-center space-x-2">
+            <AlertTriangle className="w-4 h-4 text-red-500" />
+            <p className="text-red-700 text-sm font-medium">Error</p>
+          </div>
+          <p className="text-red-600 text-sm mt-1">{error}</p>
+        </div>
+      )}
+
+      {/* Progress Display */}
+      {isRunning && (
+        <div className="mb-4 space-y-3">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center space-x-2">
+              <Loader2 className="w-4 h-4 animate-spin text-purple-600" />
+              <span className="text-sm font-medium text-purple-900">
+                {currentPhase || 'Processing...'}
+              </span>
+            </div>
+            {completedSections > 0 && (
+              <span className="text-xs text-purple-600">
+                {completedSections} sections polished
+              </span>
+            )}
+          </div>
+          
+          <div className="bg-white border border-purple-200 rounded-lg p-3">
+            <p className="text-xs text-gray-600">
+              <strong>Two-Prompt Loop:</strong> Proceed → Cleanup → Proceed → Cleanup...
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Final Results */}
+      {finalArticle && !isRunning && (
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h4 className="font-medium text-purple-900 flex items-center space-x-2">
+              <CheckCircle className="w-5 h-5 text-green-500" />
+              <span>V2 Polish Complete</span>
+            </h4>
+            {progress?.totalSections && (
+              <span className="text-sm text-gray-600">
+                {progress.totalSections} sections polished
+              </span>
+            )}
+          </div>
+          
+          <div className="bg-green-50 border border-green-200 rounded-lg p-3">
+            <p className="text-sm text-green-800">
+              <strong>Successfully balanced brand voice with semantic clarity</strong>
+              {progress?.wordCount && (
+                <span className="block mt-1 text-xs">
+                  Final word count: {progress.wordCount}
+                </span>
+              )}
+            </p>
+          </div>
+          
+          <div className="bg-white border border-purple-200 rounded-lg p-4">
+            <div className="flex items-center justify-between mb-3">
+              <h5 className="font-medium text-gray-900 flex items-center space-x-2">
+                <FileText className="w-4 h-4" />
+                <span>Polished Article</span>
+              </h5>
+              <button
+                onClick={() => navigator.clipboard.writeText(finalArticle)}
+                className="text-sm px-3 py-1 bg-purple-100 text-purple-700 rounded hover:bg-purple-200 transition-colors"
+              >
+                Copy Article
+              </button>
+            </div>
+            <div className="max-h-96 overflow-y-auto bg-gray-50 p-3 rounded border text-sm font-mono whitespace-pre-wrap">
+              {finalArticle}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Helper Text */}
+      {!isRunning && !finalArticle && !error && (
+        <div className="text-center py-8">
+          <div className="text-gray-400 mb-2">
+            <RefreshCw className="w-8 h-8 mx-auto mb-2" />
+          </div>
+          <p className="text-sm text-gray-600 mb-1">
+            Ready to polish your SEO-optimized article
+          </p>
+          <p className="text-xs text-gray-500">
+            V2 uses conversation flow: Kickoff → (Proceed → Cleanup) loop
+          </p>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/lib/agents/finalPolisherV2.ts
+++ b/lib/agents/finalPolisherV2.ts
@@ -1,0 +1,12 @@
+import { Agent } from '@openai/agents';
+
+// V2 Polish Agent - Empty instructions for LLM-driven orchestration
+export const polisherAgentV2 = new Agent({
+  name: 'FinalPolisherV2',
+  instructions: '', // CRITICAL: Empty - guidance comes from conversation prompts
+  model: 'gpt-4o-mini',
+  tools: [], // No tools needed - pure conversational flow
+});
+
+// V2 approach: Let the LLM naturally balance brand voice with semantic clarity
+// through the two-prompt loop pattern (proceed → cleanup)

--- a/lib/services/agenticFinalPolishV2Service.ts
+++ b/lib/services/agenticFinalPolishV2Service.ts
@@ -1,0 +1,415 @@
+import { Runner } from '@openai/agents';
+import { OpenAIProvider } from '@openai/agents-openai';
+import { polisherAgentV2 } from '@/lib/agents/finalPolisherV2';
+import { db } from '@/lib/db/connection';
+import { workflows, v2AgentSessions } from '@/lib/db/schema';
+import { eq, sql } from 'drizzle-orm';
+import { v4 as uuidv4 } from 'uuid';
+
+// Helper function to sanitize strings for PostgreSQL
+function sanitizeForPostgres(str: string): string {
+  if (!str) return str;
+  return str.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F]/g, '');
+}
+
+// Store active SSE connections for real-time updates
+const activeStreams = new Map<string, any>();
+
+export function addSSEConnection(sessionId: string, res: any) {
+  activeStreams.set(sessionId, res);
+}
+
+export function removeSSEConnection(sessionId: string) {
+  activeStreams.delete(sessionId);
+}
+
+function sseUpdate(sessionId: string, payload: any) {
+  const stream = activeStreams.get(sessionId);
+  if (!stream) return;
+  try {
+    stream.write(`data: ${JSON.stringify(payload)}\n\n`);
+  } catch (error) {
+    console.error('SSE push failed:', error);
+    activeStreams.delete(sessionId);
+  }
+}
+
+// The three prompts that mirror the ChatGPT tab workflow
+const KICKOFF_PROMPT = `Okay, here's my article.
+
+{ARTICLE}
+
+Review one of my project files for my brand guide and the Semantic SEO writing tips. I want you to review my article section by section, starting with the first section. Gauge how well it follows the brand guide and semantic seo tips and give it a strengths and weaknesses and update the section with some updates.`;
+
+const PROCEED_PROMPT = `Okay that is good. Now, proceed to the next section. Re-review my project files for my brand guide and the Semantic SEO writing tips. Gauge how well it follows the brand guide and semantic seo tips and give it a strengths and weaknesses and update the section with some updates. Be sure to reference the conclusions you made during your thinking process when writing the updating article. Don't use em-dashes. The updated section output should be ready to copy-paste back into my article.`;
+
+const CLEANUP_PROMPT = `Before you proceed to the next section, review your previous output. Compare it to the brand kit and the words to not use document. Based on that, make any potential updates`;
+
+export class AgenticFinalPolishV2Service {
+  private openaiProvider: OpenAIProvider;
+  
+  constructor() {
+    this.openaiProvider = new OpenAIProvider({
+      apiKey: process.env.OPENAI_API_KEY
+    });
+  }
+
+  async startSession(workflowId: string): Promise<string> {
+    try {
+      // Get the SEO-optimized article from workflow
+      const workflow = await db.select().from(workflows).where(eq(workflows.id, workflowId)).limit(1);
+      if (!workflow[0]?.content) throw new Error('Workflow not found');
+      
+      const workflowData = workflow[0].content as any;
+      const contentAuditStep = workflowData.steps?.find((s: any) => s.id === 'content-audit');
+      const articleDraftStep = workflowData.steps?.find((s: any) => s.id === 'article-draft');
+      
+      // Get SEO-optimized article or fall back to original
+      const seoOptimizedArticle = contentAuditStep?.outputs?.seoOptimizedArticle || '';
+      const originalArticle = articleDraftStep?.outputs?.fullArticle || '';
+      const fullArticle = seoOptimizedArticle || originalArticle;
+      
+      if (!fullArticle) {
+        throw new Error('No article found to polish. Complete Step 5 (Semantic SEO) first.');
+      }
+
+      // Get the next version number for this workflow
+      const maxVersionResult = await db.select({
+        maxVersion: sql<number>`COALESCE(MAX(${v2AgentSessions.version}), 0)`.as('maxVersion')
+      })
+      .from(v2AgentSessions)
+      .where(eq(v2AgentSessions.workflowId, workflowId));
+      
+      const nextVersion = (maxVersionResult[0]?.maxVersion || 0) + 1;
+      const sessionId = uuidv4();
+      const now = new Date();
+      
+      // Create session in database
+      await db.insert(v2AgentSessions).values({
+        id: sessionId,
+        workflowId,
+        version: nextVersion,
+        stepId: 'final-polish-v2',
+        status: 'initializing',
+        outline: sanitizeForPostgres(fullArticle), // Store the article to polish
+        totalSections: 0,
+        completedSections: 0,
+        sessionMetadata: {
+          startedAt: now.toISOString(),
+          version: nextVersion,
+          model: 'gpt-4o-mini',
+          usingSeoDraft: !!seoOptimizedArticle
+        },
+        startedAt: now,
+        createdAt: now,
+        updatedAt: now
+      });
+
+      console.log(`🎨 V2 Polish Session ${sessionId} created for workflow ${workflowId}, version ${nextVersion}`);
+      return sessionId;
+    } catch (error) {
+      console.error('Failed to start V2 polish session:', error);
+      throw new Error('Failed to initialize V2 polish session');
+    }
+  }
+
+  async performPolish(sessionId: string): Promise<void> {
+    try {
+      const session = await this.getSession(sessionId);
+      if (!session) throw new Error('Session not found');
+
+      const fullArticle = session.outline; // Article stored in outline field
+      if (!fullArticle) throw new Error('No article to polish in session');
+
+      await this.updateSession(sessionId, { status: 'polishing' });
+      sseUpdate(sessionId, { type: 'status', status: 'polishing', message: 'Starting brand alignment polish...' });
+
+      // Create a SINGLE conversation thread with the polisher
+      const polisherRunner = new Runner({
+        modelProvider: this.openaiProvider,
+        tracingDisabled: true
+      });
+
+      // Initialize conversation history
+      let conversationHistory: any[] = [
+        { 
+          role: 'user', 
+          content: KICKOFF_PROMPT.replace('{ARTICLE}', fullArticle)
+        }
+      ];
+
+      // Collect all polished sections
+      const polishedSections: string[] = [];
+      let sectionCount = 0;
+      const maxSections = 40; // Safety limit
+
+      // Phase 1: Send kickoff prompt
+      console.log(`📝 Sending kickoff prompt for first section...`);
+      sseUpdate(sessionId, { type: 'phase', phase: 'first_section', message: 'Analyzing first section for brand alignment...' });
+
+      let kickoffResult = await polisherRunner.run(polisherAgentV2, conversationHistory, {
+        stream: true,
+        maxTurns: 1
+      });
+
+      let kickoffResponse = '';
+      
+      for await (const event of kickoffResult.toStream()) {
+        if (event.type === 'raw_model_stream_event' && event.data.type === 'output_text_delta') {
+          kickoffResponse += event.data.delta || '';
+          sseUpdate(sessionId, { type: 'text', content: event.data.delta });
+        }
+      }
+
+      await kickoffResult.finalOutput;
+      conversationHistory = (kickoffResult as any).history;
+      
+      if (!conversationHistory || conversationHistory.length === 0) {
+        throw new Error('No history returned from SDK');
+      }
+
+      // Extract the response (strengths, weaknesses, updated section)
+      const firstSectionAnalysis = this.extractAssistantResponse(conversationHistory);
+      console.log(`✅ First section analysis complete: ${firstSectionAnalysis.length} chars`);
+
+      // Phase 2: Cleanup the first section
+      console.log(`🧹 Sending cleanup prompt for first section...`);
+      sseUpdate(sessionId, { type: 'phase', phase: 'cleanup', message: 'Refining first section based on brand kit...' });
+
+      conversationHistory.push({ role: 'user', content: CLEANUP_PROMPT });
+
+      let cleanupResult = await polisherRunner.run(polisherAgentV2, conversationHistory, {
+        stream: true,
+        maxTurns: 1
+      });
+
+      let cleanupResponse = '';
+      for await (const event of cleanupResult.toStream()) {
+        if (event.type === 'raw_model_stream_event' && event.data.type === 'output_text_delta') {
+          cleanupResponse += event.data.delta || '';
+          sseUpdate(sessionId, { type: 'text', content: event.data.delta });
+        }
+      }
+
+      await cleanupResult.finalOutput;
+      conversationHistory = (cleanupResult as any).history;
+
+      const firstSectionPolished = this.extractAssistantResponse(conversationHistory);
+      polishedSections.push(firstSectionPolished);
+      sectionCount = 1;
+
+      await this.updateSession(sessionId, { completedSections: sectionCount });
+      sseUpdate(sessionId, { 
+        type: 'section_completed', 
+        sectionNumber: sectionCount, 
+        content: firstSectionPolished,
+        message: 'First section polished'
+      });
+
+      // Phase 3: Loop through remaining sections with two-prompt pattern
+      let continuePolishing = true;
+      
+      while (continuePolishing && sectionCount < maxSections) {
+        // Step 1: Proceed to next section
+        console.log(`📝 Sending proceed prompt for section ${sectionCount + 1}...`);
+        sseUpdate(sessionId, { 
+          type: 'phase', 
+          phase: 'analyzing', 
+          message: `Analyzing section ${sectionCount + 1} for brand alignment...` 
+        });
+
+        conversationHistory.push({ role: 'user', content: PROCEED_PROMPT });
+
+        let proceedResult = await polisherRunner.run(polisherAgentV2, conversationHistory, {
+          stream: true,
+          maxTurns: 1
+        });
+
+        let proceedResponse = '';
+        for await (const event of proceedResult.toStream()) {
+          if (event.type === 'raw_model_stream_event' && event.data.type === 'output_text_delta') {
+            proceedResponse += event.data.delta || '';
+            sseUpdate(sessionId, { type: 'text', content: event.data.delta });
+          }
+        }
+
+        await proceedResult.finalOutput;
+        conversationHistory = (proceedResult as any).history;
+
+        const sectionAnalysis = this.extractAssistantResponse(conversationHistory);
+        
+        // Check if we've reached the end (AI might indicate no more sections)
+        if (this.checkIfComplete(sectionAnalysis)) {
+          console.log(`✅ Polish complete - AI indicated no more sections after ${sectionCount} sections`);
+          continuePolishing = false;
+          break;
+        }
+
+        // Step 2: Cleanup this section
+        console.log(`🧹 Sending cleanup prompt for section ${sectionCount + 1}...`);
+        sseUpdate(sessionId, { 
+          type: 'phase', 
+          phase: 'cleanup', 
+          message: `Refining section ${sectionCount + 1} based on brand kit...` 
+        });
+
+        conversationHistory.push({ role: 'user', content: CLEANUP_PROMPT });
+
+        let cleanupResult2 = await polisherRunner.run(polisherAgentV2, conversationHistory, {
+          stream: true,
+          maxTurns: 1
+        });
+
+        let cleanupResponse2 = '';
+        for await (const event of cleanupResult2.toStream()) {
+          if (event.type === 'raw_model_stream_event' && event.data.type === 'output_text_delta') {
+            cleanupResponse2 += event.data.delta || '';
+            sseUpdate(sessionId, { type: 'text', content: event.data.delta });
+          }
+        }
+
+        await cleanupResult2.finalOutput;
+        conversationHistory = (cleanupResult2 as any).history;
+
+        const sectionPolished = this.extractAssistantResponse(conversationHistory);
+        polishedSections.push(sectionPolished);
+        sectionCount++;
+
+        await this.updateSession(sessionId, { completedSections: sectionCount });
+        sseUpdate(sessionId, { 
+          type: 'section_completed', 
+          sectionNumber: sectionCount, 
+          content: sectionPolished,
+          message: `Section ${sectionCount} polished`
+        });
+
+        // Safety check for section limit
+        if (sectionCount >= 35) {
+          console.log(`⚠️ Approaching section limit (${sectionCount}/${maxSections})`);
+        }
+      }
+
+      // Assemble final polished article
+      const finalPolishedArticle = polishedSections.join('\n\n');
+      const wordCount = finalPolishedArticle.split(/\s+/).filter(Boolean).length;
+
+      console.log(`✅ Polish completed: ${wordCount} words, ${sectionCount} sections`);
+
+      // Save final polished article
+      await this.savePolishedArticleToWorkflow(session.workflowId, finalPolishedArticle);
+      
+      await this.updateSession(sessionId, {
+        status: 'completed',
+        finalArticle: sanitizeForPostgres(finalPolishedArticle),
+        totalWordCount: wordCount,
+        totalSections: sectionCount,
+        completedAt: new Date()
+      });
+      
+      sseUpdate(sessionId, {
+        type: 'completed',
+        finalPolishedArticle: finalPolishedArticle,
+        wordCount: wordCount,
+        totalSections: sectionCount,
+        message: 'Polish completed successfully!'
+      });
+
+    } catch (error: any) {
+      console.error('❌ V2 polish failed:', error);
+      await this.updateSession(sessionId, {
+        status: 'failed',
+        errorMessage: error.message
+      });
+      sseUpdate(sessionId, { type: 'error', error: error.message });
+      throw error;
+    }
+  }
+
+  private extractAssistantResponse(conversationHistory: any[]): string {
+    const assistantMessages = conversationHistory.filter((item: any) => 
+      item.role === 'assistant' && item.type === 'message'
+    );
+    
+    if (assistantMessages.length === 0) return '';
+    
+    const lastAssistant = assistantMessages[assistantMessages.length - 1];
+    
+    if (typeof lastAssistant.content === 'string') {
+      return lastAssistant.content;
+    } else if (Array.isArray(lastAssistant.content)) {
+      return lastAssistant.content
+        .filter((item: any) => item.type === 'text' || item.type === 'output_text')
+        .map((item: any) => item.text || '')
+        .join('');
+    }
+    
+    return '';
+  }
+
+  private checkIfComplete(response: string): boolean {
+    // Check for common indicators that there are no more sections
+    const lowerResponse = response.toLowerCase();
+    return (
+      lowerResponse.includes('no more sections') ||
+      lowerResponse.includes('all sections have been') ||
+      lowerResponse.includes('final section') ||
+      lowerResponse.includes('last section') ||
+      lowerResponse.includes('article is complete') ||
+      lowerResponse.includes('polish is complete')
+    );
+  }
+
+  private async savePolishedArticleToWorkflow(workflowId: string, polishedArticle: string): Promise<void> {
+    const workflow = await db.select().from(workflows).where(eq(workflows.id, workflowId)).limit(1);
+    if (workflow[0]?.content) {
+      const workflowData = workflow[0].content as any;
+      const polishStep = workflowData.steps?.find((step: any) => step.id === 'final-polish');
+      
+      if (polishStep) {
+        polishStep.outputs = {
+          ...polishStep.outputs,
+          finalArticle: polishedArticle,
+          polishProgress: '100',
+          tab3Created: 'yes',
+          agentV2Generated: true,
+          generatedAt: new Date().toISOString()
+        };
+
+        await db.update(workflows)
+          .set({
+            content: workflowData,
+            updatedAt: new Date()
+          })
+          .where(eq(workflows.id, workflowId));
+      }
+    }
+  }
+
+  private async getSession(sessionId: string) {
+    const sessions = await db.select().from(v2AgentSessions).where(eq(v2AgentSessions.id, sessionId)).limit(1);
+    return sessions[0] || null;
+  }
+
+  private async updateSession(sessionId: string, updates: Partial<any>) {
+    await db.update(v2AgentSessions)
+      .set({ ...updates, updatedAt: new Date() })
+      .where(eq(v2AgentSessions.id, sessionId));
+  }
+
+  async getSessionProgress(sessionId: string) {
+    const session = await this.getSession(sessionId);
+    if (!session) return null;
+
+    return {
+      session,
+      progress: {
+        status: session.status,
+        completedSections: session.completedSections || 0,
+        totalSections: session.totalSections || 0,
+        errorMessage: session.errorMessage
+      }
+    };
+  }
+}
+
+export const agenticFinalPolishV2Service = new AgenticFinalPolishV2Service();


### PR DESCRIPTION
- Create finalPolisherV2 agent with empty instructions for LLM-driven flow
- Implement agenticFinalPolishV2Service with exact ChatGPT tab prompts:
  - Kickoff prompt for first section
  - Proceed prompt for next sections
  - Cleanup prompt after each section
- Add API endpoints for V2 polish (start/stream)
- Create AgenticFinalPolisherV2 UI component
- Add V2 tab as default in FinalPolishStepClean
- Mirror exact two-prompt loop workflow from ChatGPT tab

The V2 implementation automates the manual ChatGPT workflow while preserving the exact prompts and two-step pattern that balances brand voice with semantic clarity.

🤖 Generated with [Claude Code](https://claude.ai/code)