### PR TITLE
fix: Update route params to use Promise for Next.js 15 compatibility

### DIFF
--- a/app/api/workflows/[id]/final-polish-v2/start/route.ts
+++ b/app/api/workflows/[id]/final-polish-v2/start/route.ts
@@ -3,10 +3,10 @@ import { agenticFinalPolishV2Service } from '@/lib/services/agenticFinalPolishV2
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const workflowId = params.id;
+    const { id: workflowId } = await params;
     console.log(`📝 Starting V2 polish session for workflow ${workflowId}`);
     
     // Start the session

--- a/app/api/workflows/[id]/final-polish-v2/stream/route.ts
+++ b/app/api/workflows/[id]/final-polish-v2/stream/route.ts
@@ -3,7 +3,7 @@ import { agenticFinalPolishV2Service, addSSEConnection, removeSSEConnection } fr
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   const sessionId = request.nextUrl.searchParams.get('sessionId');
   


### PR DESCRIPTION
- Update final-polish-v2 POST route to use Promise<{ id: string }>
- Update final-polish-v2 GET route to use Promise<{ id: string }>
- Await params before accessing id property

This fixes the TypeScript error in Next.js 15 where route params are now async and must be awaited.

🤖 Generated with [Claude Code](https://claude.ai/code)