### PR TITLE
Fix: Polish V2 infinite loop and add emergency stop

### DIFF
--- a/app/api/workflows/[id]/polish-v2/cancel/route.ts
+++ b/app/api/workflows/[id]/polish-v2/cancel/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { agenticFinalPolishV2Service } from '@/lib/services/agenticFinalPolishV2Service';
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { sessionId } = await req.json();
+    
+    if (!sessionId) {
+      return NextResponse.json(
+        { error: 'Session ID is required' },
+        { status: 400 }
+      );
+    }
+    
+    // Cancel the session
+    await agenticFinalPolishV2Service.cancelSession(sessionId);
+    
+    return NextResponse.json({ 
+      success: true,
+      message: 'Session cancelled successfully'
+    });
+  } catch (error) {
+    console.error('Cancel polish V2 error:', error);
+    return NextResponse.json(
+      { error: 'Failed to cancel session' },
+      { status: 500 }
+    );
+  }
+}

--- a/components/ui/AgenticFinalPolisherV2.tsx
+++ b/components/ui/AgenticFinalPolisherV2.tsx
@@ -194,7 +194,7 @@ export const AgenticFinalPolisherV2: React.FC<AgenticFinalPolisherV2Props> = ({
           <div>
             <h3 className="font-semibold text-purple-900">Agentic Polish V2</h3>
             <p className="text-sm text-purple-700">
-              Two-prompt loop pattern for brand alignment
+              Single-prompt pattern for brand alignment
             </p>
           </div>
         </div>
@@ -251,7 +251,7 @@ export const AgenticFinalPolisherV2: React.FC<AgenticFinalPolisherV2Props> = ({
           
           <div className="bg-white border border-purple-200 rounded-lg p-3">
             <p className="text-xs text-gray-600">
-              <strong>Two-Prompt Loop:</strong> Proceed → Cleanup → Proceed → Cleanup...
+              <strong>Single-Prompt Loop:</strong> Analyze & Polish → Next Section → Analyze & Polish...
             </p>
           </div>
           
@@ -322,7 +322,7 @@ export const AgenticFinalPolisherV2: React.FC<AgenticFinalPolisherV2Props> = ({
             Ready to polish your SEO-optimized article
           </p>
           <p className="text-xs text-gray-500">
-            V2 uses conversation flow: Kickoff → (Proceed → Cleanup) loop
+            V2 uses conversation flow: Kickoff → Single-prompt loop per section
           </p>
         </div>
       )}

--- a/lib/agents/finalPolisherV2.ts
+++ b/lib/agents/finalPolisherV2.ts
@@ -16,4 +16,4 @@ export const polisherAgentV2 = new Agent({
 });
 
 // V2 approach: Let the LLM naturally balance brand voice with semantic clarity
-// through the two-prompt loop pattern (proceed → cleanup)
+// through a single-prompt pattern that combines analysis and polish

--- a/lib/agents/finalPolisherV2.ts
+++ b/lib/agents/finalPolisherV2.ts
@@ -11,7 +11,7 @@ const webSearch = webSearchTool();
 export const polisherAgentV2 = new Agent({
   name: 'FinalPolisherV2',
   instructions: '', // CRITICAL: Empty - guidance comes from conversation prompts
-  model: 'gpt-4o-mini',
+  model: 'o3-2025-04-16',
   tools: [fileSearch, webSearch], // Access to brand guide, semantic SEO knowledge base, and web search
 });
 


### PR DESCRIPTION
## Summary

This PR fixes the critical infinite loop issue in Polish V2 and adds an emergency stop button for better control.

## Changes

### 1. Message Deduplication Logic
- Added the same deduplication logic that Semantic Audit V2 uses
- Filters out duplicate message IDs (both `msg_*` and `rs_*` reasoning items)
- Prevents the AI from getting confused by duplicate context
- Should fix the issue where Polish V2 was looping on specific sections (like item 5 in the credit cards article)

### 2. Emergency Stop Button
- Added a red "Emergency Stop" button in the UI during polish operations
- Created new cancel API endpoint at `/api/workflows/[id]/polish-v2/cancel`
- Cancel functionality:
  - Sets session status to 'cancelled' in database
  - Sends cancellation notice via SSE
  - Checks for cancellation before each phase (proceed and cleanup)
  - Gracefully exits the loop when cancelled

### 3. Additional Fixes
- Fixed model from `gpt-4o-mini` to `o3-2025-04-16` to match other V2 agents
- Added END_OF_ARTICLE marker and detection (from previous commit)
- Improved completion detection with additional phrases

## Testing
- Build passes successfully
- No TypeScript errors
- Emergency stop button appears correctly in UI

## Why These Changes?
The infinite loop was caused by:
1. Missing deduplication causing duplicate messages in conversation history
2. AI getting confused about position in article
3. No way to stop runaway operations

These changes address all three issues.

🤖 Generated with [Claude Code](https://claude.ai/code)