### PR TITLE
fix: ArticleEndCritic completion detection - stop immediately when co…

### DIFF
--- a/lib/services/agenticArticleV2Service.ts
+++ b/lib/services/agenticArticleV2Service.ts
@@ -437,6 +437,7 @@ export class AgenticArticleV2Service {
         if (sectionParsed.status === 'complete') {
           articleComplete = true;
           console.log(`✅ Article complete - writer signaled completion after ${sectionCount + 1} sections`);
+          break; // Exit immediately when writer signals completion
         } else if (sectionParsed.content) {
           // Add content to sections array
           articleSections.push(sectionParsed.content);
@@ -503,6 +504,7 @@ export class AgenticArticleV2Service {
                 phase: 'completed', 
                 message: `Article complete - proper conclusion detected after ${sectionCount} sections` 
               });
+              break; // Exit the loop immediately when article is complete
             } else {
               console.log(`⏩ Article not complete yet - continuing...`);
             }


### PR DESCRIPTION
…mplete

The critic was working correctly (logs showed "ArticleEndCritic verdict: YES") but the loop structure was causing one more section to be requested after completion was detected.

Added break statements to exit the loop immediately when:
- ArticleEndCritic returns YES verdict
- Writer signals completion with <<<ARTICLE_COMPLETE>>> delimiter

This prevents the article from continuing past its natural conclusion.

🤖 Generated with [Claude Code](https://claude.ai/code)