### PR TITLE
Fix: Add completion instruction to semantic audit V2 looping prompt

### DIFF
--- a/lib/services/agenticSemanticAuditV2Service.ts
+++ b/lib/services/agenticSemanticAuditV2Service.ts
@@ -239,7 +239,7 @@ Important:
 - The suggestedVersion should preserve markdown formatting (headings, lists, bold, italics, etc.)
 - When you identify weaknesses related to lack of numbers or data, DO NOT make up data. Instead, use the web search tool to find accurate, factual data to support your improvements
 
-`;
+When you reach the end of the article or see <!-- END_OF_ARTICLE -->, output exactly: ===AUDIT_COMPLETE===`;
 
       // Initialize conversation
       let messages: any[] = [


### PR DESCRIPTION
## Summary
- Adds the missing `===AUDIT_COMPLETE===` instruction to the looping prompt
- Keeps initial prompt without completion instruction (correct behavior)
- Fixes issue where audit was not properly signaling completion

## Problem
The semantic audit V2 was failing with "No audited article received from server" because the looping prompt was missing the instruction to output `===AUDIT_COMPLETE===` when reaching the end marker.

## Solution
Added the completion instruction only to the looping prompt where it belongs, ensuring the AI signals completion only after processing all sections.

🤖 Generated with [Claude Code](https://claude.ai/code)