### PR TITLE
feat: Improve topic preferences UI with cleaner preset display

### DIFF
--- a/components/steps/TopicGenerationImproved.tsx
+++ b/components/steps/TopicGenerationImproved.tsx
@@ -310,9 +310,10 @@ Target URL: ${clientTargetUrl}`;
                 {onWorkflowChange ? (
                   <div className="space-y-3">
                     <KeywordPreferencesSelector
-                      preferences={getWorkflowKeywordPreferences(workflow) || undefined}
+                      preferences={keywordPreferences || undefined}
                       onChange={handleKeywordPreferencesChange}
                       compact={true}
+                      isPreset={!!keywordPreferences}
                     />
                     
                     {getWorkflowKeywordPreferences(workflow) && (


### PR DESCRIPTION
- Hide dropdown when preferences are preset (workflow/client level)
- Show current focus with "Change for this workflow" option
- Remove redundant "Guest Post Topic Focus" label when editing
- Cleaner UI reduces confusion between preference name and selector

🤖 Generated with [Claude Code](https://claude.ai/code)