### PR TITLE
Fix citation handling and add article title/tag cleanup to Formatting QA

### DIFF
--- a/components/steps/FormattingQAStepClean.tsx
+++ b/components/steps/FormattingQAStepClean.tsx
@@ -148,7 +148,7 @@ export const FormattingQAStepClean = ({ step, workflow, onChange }: FormattingQA
             <div className="bg-red-50 p-4 rounded-md">
               <h4 className="font-semibold mb-2">Citation Requirements</h4>
               <p className="text-sm mb-2">
-                <strong>Single citation near the top:</strong> One "[citation]" or "[1]" marker in intro/first section only
+                <strong>Single citation link allowed:</strong> Only 1 hyperlink citation in the entire article (preferably near top). All other sources should be mentioned without links (e.g., "According to Gartner...")
               </p>
               <p className="text-sm font-semibold text-red-700">
                 REMOVE source UTM parameter of chatgpt from any URLs

--- a/components/ui/AgenticFormattingChecker.tsx
+++ b/components/ui/AgenticFormattingChecker.tsx
@@ -135,7 +135,9 @@ export function AgenticFormattingChecker({ workflowId, onComplete }: AgenticForm
     bold_cleanup: 'Bold Cleanup',
     faq_formatting: 'FAQ Formatting',
     citation_placement: 'Citation Placement',
-    utm_cleanup: 'UTM Cleanup'
+    utm_cleanup: 'UTM Cleanup',
+    article_title: 'Article Title',
+    tag_cleanup: 'Tag Cleanup'
   };
 
   const startQACheck = async () => {
@@ -144,7 +146,7 @@ export function AgenticFormattingChecker({ workflowId, onComplete }: AgenticForm
       setError(null);
       setStatus('starting');
       setChecks([]);
-      setOverallStats({ total: 8, passed: 0, failed: 0 });
+      setOverallStats({ total: 10, passed: 0, failed: 0 });
 
       // Start QA session
       const response = await fetch(`/api/workflows/${workflowId}/formatting-qa/start`, {


### PR DESCRIPTION
- Updated citation handling to keep only 1 citation link per article
- Convert remaining citations to verbal attributions based on URL domain
- Only add attribution for data/stats, not common knowledge
- Removed web search tool since citations already exist in articles
- Added article title check to ensure H1 is present at top
- Added tag cleanup to remove internal markers (<\!-- END_OF_ARTICLE -->, etc.)
- Updated check count from 8 to 10 in UI and service
- Updated manual checklist text to reflect single citation requirement

🤖 Generated with [Claude Code](https://claude.ai/code)