### PR TITLE
Fix deployment error: Add missing linkOrchestrationSessions export

### DIFF
--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -285,6 +285,7 @@ export const workflowsRelations = relations(workflows, ({ one, many }) => ({
   }),
   steps: many(workflowSteps),
   articleSections: many(articleSections),
+  linkOrchestrationSessions: many(linkOrchestrationSessions),
   agentSessions: many(agentSessions),
   auditSessions: many(auditSessions),
   auditSections: many(auditSections),
@@ -471,3 +472,68 @@ export const v2AgentSessionsRelations = relations(v2AgentSessions, ({ one }) => 
 
 export type V2AgentSession = typeof v2AgentSessions.$inferSelect;
 export type NewV2AgentSession = typeof v2AgentSessions.$inferInsert;
+
+// Link Orchestration Sessions
+export const linkOrchestrationSessions = pgTable('link_orchestration_sessions', {
+  id: uuid('id').primaryKey(),
+  workflowId: uuid('workflow_id').notNull().references(() => workflows.id),
+  version: integer('version').notNull().default(1),
+  status: varchar('status', { length: 50 }).notNull(), // 'initializing', 'phase1', 'phase2', 'phase3', 'completed', 'failed'
+  
+  // Phase tracking
+  currentPhase: integer('current_phase').default(1),
+  phase1Start: timestamp('phase1_start'),
+  phase1Complete: timestamp('phase1_complete'),
+  phase2Start: timestamp('phase2_start'),
+  phase2Complete: timestamp('phase2_complete'),
+  phase3Start: timestamp('phase3_start'),
+  phase3Complete: timestamp('phase3_complete'),
+  
+  // Article versions
+  originalArticle: text('original_article').notNull(),
+  articleAfterPhase1: text('article_after_phase1'),
+  articleAfterPhase2: text('article_after_phase2'),
+  finalArticle: text('final_article'),
+  
+  // Input parameters
+  targetDomain: text('target_domain').notNull(),
+  clientName: varchar('client_name', { length: 255 }).notNull(),
+  clientUrl: text('client_url').notNull(),
+  anchorText: varchar('anchor_text', { length: 255 }),
+  guestPostSite: text('guest_post_site').notNull(),
+  targetKeyword: varchar('target_keyword', { length: 255 }).notNull(),
+  
+  // Results stored as JSONB
+  phase1Results: jsonb('phase1_results'),
+  phase2Results: jsonb('phase2_results'),
+  phase3Results: jsonb('phase3_results'),
+  internalLinksResult: jsonb('internal_links_result'),
+  clientMentionResult: jsonb('client_mention_result'),
+  clientLinkResult: jsonb('client_link_result'),
+  clientLinkConversation: jsonb('client_link_conversation'),
+  imageStrategy: jsonb('image_strategy'),
+  linkRequests: text('link_requests'),
+  urlSuggestion: text('url_suggestion'),
+  
+  // Error tracking
+  errorMessage: text('error_message'),
+  errorDetails: jsonb('error_details'),
+  
+  // Timestamps
+  startedAt: timestamp('started_at').default(new Date()),
+  completedAt: timestamp('completed_at'),
+  failedAt: timestamp('failed_at'),
+  
+  createdAt: timestamp('created_at').default(new Date()),
+  updatedAt: timestamp('updated_at').default(new Date()),
+});
+
+export const linkOrchestrationSessionsRelations = relations(linkOrchestrationSessions, ({ one }) => ({
+  workflow: one(workflows, {
+    fields: [linkOrchestrationSessions.workflowId],
+    references: [workflows.id],
+  }),
+}));
+
+export type LinkOrchestrationSession = typeof linkOrchestrationSessions.$inferSelect;
+export type NewLinkOrchestrationSession = typeof linkOrchestrationSessions.$inferInsert;


### PR DESCRIPTION
- Added complete linkOrchestrationSessions table definition to schema.ts
- Fixed missing export that was causing build failures
- Table includes all necessary fields for link orchestration tracking
- Resolves deployment error: 'linkOrchestrationSessions' is not exported

🤖 Generated with [Claude Code](https://claude.ai/code)