### PR TITLE
Fix link orchestration database issues

### DIFF
--- a/app/admin/link-orchestration-diagnostics/page.tsx
+++ b/app/admin/link-orchestration-diagnostics/page.tsx
@@ -202,6 +202,37 @@ export default function LinkOrchestrationDiagnosticsPage() {
     }
   };
 
+  const testPatchedInsert = async () => {
+    try {
+      const testData = {
+        article: 'Test article content',
+        targetDomain: 'example.com',
+        clientName: 'Test Client',
+        clientUrl: 'https://testclient.com',
+        anchorText: 'test anchor',
+        guestPostSite: 'testblog.com',
+        targetKeyword: 'test keyword'
+      };
+
+      const response = await fetch('/api/admin/patch-link-orchestration-service', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(testData)
+      });
+      
+      const data = await response.json();
+      
+      if (data.success) {
+        alert(`✅ Test insert successful! Session ID: ${data.sessionId}`);
+        console.log('Insert result:', data);
+      } else {
+        alert(`❌ Test insert failed: ${data.error}\n\nDetails: ${JSON.stringify(data.details, null, 2)}`);
+      }
+    } catch (error: any) {
+      alert(`❌ Error testing insert: ${error.message}`);
+    }
+  };
+
   const runTestOrchestration = async () => {
     setTestOrchestration({
       status: 'running',
@@ -490,6 +521,14 @@ SEO success requires a holistic approach that combines quality content, technica
               >
                 <Settings className="w-4 h-4" />
                 Fix Schema
+              </button>
+              
+              <button
+                onClick={testPatchedInsert}
+                className="px-4 py-2 bg-yellow-600 text-white rounded hover:bg-yellow-700 flex items-center gap-2"
+              >
+                <Zap className="w-4 h-4" />
+                Test Patched Insert
               </button>
             </div>
 

--- a/app/api/admin/patch-link-orchestration-service/route.ts
+++ b/app/api/admin/patch-link-orchestration-service/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/lib/db/connection';
+import { linkOrchestrationSessions } from '@/lib/db/schema';
+import { v4 as uuidv4 } from 'uuid';
+
+export const runtime = 'nodejs';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const {
+      article,
+      targetDomain,
+      clientName,
+      clientUrl,
+      anchorText,
+      guestPostSite,
+      targetKeyword
+    } = body;
+
+    const sessionId = uuidv4();
+    // Use a proper UUID for workflow_id since it's defined as UUID type in the table
+    const testWorkflowId = uuidv4();
+    const now = new Date();
+
+    console.log('[Patch Test] Attempting corrected insert with proper column mapping');
+    console.log('[Patch Test] Session ID:', sessionId);
+    console.log('[Patch Test] Workflow ID:', testWorkflowId);
+
+    // Try the corrected insert
+    const result = await db.insert(linkOrchestrationSessions).values({
+      id: sessionId,
+      workflowId: testWorkflowId,
+      version: 1,
+      status: 'initializing',
+      originalArticle: article,
+      targetDomain: targetDomain,
+      clientName: clientName,
+      clientUrl: clientUrl,
+      anchorText: anchorText || null,
+      guestPostSite: guestPostSite,
+      targetKeyword: targetKeyword,
+      currentPhase: 0,
+      // Don't include startedAt, createdAt, updatedAt - let the database defaults handle them
+      // The schema shows these have default values
+    }).returning();
+
+    console.log('[Patch Test] Insert successful:', result);
+
+    return NextResponse.json({
+      success: true,
+      message: 'Test insert successful with corrected column mapping',
+      sessionId: sessionId,
+      result: result
+    });
+  } catch (error: any) {
+    console.error('[Patch Test] Error:', error);
+    
+    return NextResponse.json({
+      success: false,
+      error: error.message,
+      details: {
+        code: error.code,
+        detail: error.detail,
+        hint: error.hint,
+        position: error.position
+      }
+    }, { status: 500 });
+  }
+}

--- a/app/api/admin/test-link-orchestration/route.ts
+++ b/app/api/admin/test-link-orchestration/route.ts
@@ -23,8 +23,8 @@ export async function POST(request: NextRequest) {
       useStreaming = true
     } = body;
 
-    // Create a temporary workflow ID for testing
-    const testWorkflowId = `test-${uuidv4()}`;
+    // Create a temporary workflow ID for testing - must be a valid UUID
+    const testWorkflowId = uuidv4();
     
     console.log('[Test Link Orchestration] Test parameters:', {
       testWorkflowId,

--- a/lib/services/linkOrchestrationService.ts
+++ b/lib/services/linkOrchestrationService.ts
@@ -108,10 +108,8 @@ export class LinkOrchestrationService {
         anchorText: input.anchorText || null,
         guestPostSite: input.guestPostSite,
         targetKeyword: input.targetKeyword,
-        currentPhase: 0,
-        startedAt: startTime,
-        createdAt: startTime,
-        updatedAt: startTime
+        currentPhase: 0
+        // Remove startedAt, createdAt, updatedAt - database defaults will handle them
       });
 
       // Phase 1: Internal Links + Client Mentions (Parallel)


### PR DESCRIPTION
- Fixed workflow_id must be proper UUID (not 'test-' prefix)
- Removed timestamp fields from insert (let database defaults handle them)
- Added test patched insert button to diagnostic page
- Created patch test endpoint to verify the fix works

The main issues were:
1. workflow_id was using string format instead of UUID
2. Insert was trying to use non-existent timestamp columns
3. The schema expected snake_case but service was using camelCase

This should resolve the database insert errors preventing orchestration from running.