### PR TITLE
feat: Add Airtable metadata filters to website directory

### DIFF
--- a/app/api/websites/search/route.ts
+++ b/app/api/websites/search/route.ts
@@ -56,7 +56,9 @@ export async function POST(request: NextRequest) {
       overallQuality: w.overall_quality,
       contacts: w.contacts || [],
       qualification: w.qualification,
-      lastSyncedAt: w.last_synced_at
+      lastSyncedAt: w.last_synced_at,
+      airtableCreatedAt: w.airtable_created_at,
+      airtableUpdatedAt: w.airtable_updated_at
     }));
     
     return NextResponse.json({

--- a/app/websites/page.tsx
+++ b/app/websites/page.tsx
@@ -43,6 +43,8 @@ interface Website {
   publishedOpportunities: number;
   overallQuality: string | null;
   lastSyncedAt: string;
+  airtableCreatedAt?: string;
+  airtableUpdatedAt?: string;
   contacts: Array<{
     id: string;
     email: string;
@@ -74,6 +76,11 @@ interface Filters {
   status?: string;
   qualificationStatus?: 'all' | 'qualified' | 'unqualified';
   clientId?: string;
+  // Airtable metadata filters
+  airtableUpdatedAfter?: string;
+  airtableUpdatedBefore?: string;
+  lastSyncedAfter?: string;
+  lastSyncedBefore?: string;
 }
 
 function WebsitesPageContent() {
@@ -118,7 +125,11 @@ function WebsitesPageContent() {
             categories: filters.categories,
             hasGuestPost: filters.hasGuestPost,
             hasLinkInsert: filters.hasLinkInsert,
-            status: filters.status
+            status: filters.status,
+            airtableUpdatedAfter: filters.airtableUpdatedAfter,
+            airtableUpdatedBefore: filters.airtableUpdatedBefore,
+            lastSyncedAfter: filters.lastSyncedAfter,
+            lastSyncedBefore: filters.lastSyncedBefore
           },
           limit: 50,
           offset: page * 50,
@@ -516,6 +527,74 @@ function WebsitesPageContent() {
                   </select>
                 </div>
               )}
+            </div>
+          )}
+
+          {/* Airtable Metadata Filters */}
+          {showFilters && (
+            <div className="mt-4">
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                Airtable Metadata Filters
+              </label>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                {/* Airtable Updated Date Range */}
+                <div>
+                  <label className="block text-sm font-medium text-gray-600 mb-1">
+                    Airtable Updated Date
+                  </label>
+                  <div className="flex gap-2">
+                    <input
+                      type="date"
+                      placeholder="From"
+                      className="w-1/2 px-3 py-1.5 border rounded text-sm"
+                      value={filters.airtableUpdatedAfter || ''}
+                      onChange={(e) => setFilters(prev => ({ 
+                        ...prev, 
+                        airtableUpdatedAfter: e.target.value || undefined 
+                      }))}
+                    />
+                    <input
+                      type="date"
+                      placeholder="To"
+                      className="w-1/2 px-3 py-1.5 border rounded text-sm"
+                      value={filters.airtableUpdatedBefore || ''}
+                      onChange={(e) => setFilters(prev => ({ 
+                        ...prev, 
+                        airtableUpdatedBefore: e.target.value || undefined 
+                      }))}
+                    />
+                  </div>
+                </div>
+
+                {/* Last Synced Date Range */}
+                <div>
+                  <label className="block text-sm font-medium text-gray-600 mb-1">
+                    Last Synced Date
+                  </label>
+                  <div className="flex gap-2">
+                    <input
+                      type="date"
+                      placeholder="From"
+                      className="w-1/2 px-3 py-1.5 border rounded text-sm"
+                      value={filters.lastSyncedAfter || ''}
+                      onChange={(e) => setFilters(prev => ({ 
+                        ...prev, 
+                        lastSyncedAfter: e.target.value || undefined 
+                      }))}
+                    />
+                    <input
+                      type="date"
+                      placeholder="To"
+                      className="w-1/2 px-3 py-1.5 border rounded text-sm"
+                      value={filters.lastSyncedBefore || ''}
+                      onChange={(e) => setFilters(prev => ({ 
+                        ...prev, 
+                        lastSyncedBefore: e.target.value || undefined 
+                      }))}
+                    />
+                  </div>
+                </div>
+              </div>
             </div>
           )}
 

--- a/components/websites/WebsiteDetailModal.tsx
+++ b/components/websites/WebsiteDetailModal.tsx
@@ -51,6 +51,8 @@ interface Website {
   lastSyncedAt: string;
   createdAt: string;
   updatedAt: string;
+  airtableCreatedAt?: string;
+  airtableUpdatedAt?: string;
   // Additional fields from Airtable
   domainAuthority?: number | null;
   spamScore?: number | null;
@@ -332,6 +334,9 @@ export default function WebsiteDetailModal({
                   {/* Timestamps */}
                   <div className="text-sm text-gray-500 space-y-1">
                     <div>Last synced: {format(new Date(website.lastSyncedAt), 'PPp')}</div>
+                    {website.airtableUpdatedAt && (
+                      <div>Airtable updated: {format(new Date(website.airtableUpdatedAt), 'PPp')}</div>
+                    )}
                     <div>Added to database: {format(new Date(website.createdAt), 'PP')}</div>
                   </div>
                 </div>

--- a/lib/services/airtableSyncService.ts
+++ b/lib/services/airtableSyncService.ts
@@ -266,6 +266,27 @@ export class AirtableSyncService {
       params.push(filters.categories);
     }
     
+    // Airtable metadata filters
+    if (filters.airtableUpdatedAfter) {
+      conditions.push(`w.airtable_updated_at >= $${paramIndex++}`);
+      params.push(filters.airtableUpdatedAfter);
+    }
+    
+    if (filters.airtableUpdatedBefore) {
+      conditions.push(`w.airtable_updated_at <= $${paramIndex++}`);
+      params.push(filters.airtableUpdatedBefore);
+    }
+    
+    if (filters.lastSyncedAfter) {
+      conditions.push(`w.last_synced_at >= $${paramIndex++}`);
+      params.push(filters.lastSyncedAfter);
+    }
+    
+    if (filters.lastSyncedBefore) {
+      conditions.push(`w.last_synced_at <= $${paramIndex++}`);
+      params.push(filters.lastSyncedBefore);
+    }
+    
     // Handle qualification filters
     let joinClause = '';
     if (filters.clientId && (filters.onlyQualified || filters.onlyUnqualified)) {

--- a/types/airtable.ts
+++ b/types/airtable.ts
@@ -87,4 +87,9 @@ export interface WebsiteFilters {
   categories?: string[];
   searchTerm?: string;
   forceAllRecords?: boolean; // Skip view filtering for full sync
+  // Airtable metadata filters
+  airtableUpdatedAfter?: string; // ISO date string
+  airtableUpdatedBefore?: string; // ISO date string
+  lastSyncedAfter?: string; // ISO date string
+  lastSyncedBefore?: string; // ISO date string
 }


### PR DESCRIPTION
- Add date range filters for Airtable updated and last synced timestamps
- Enable filtering by airtable_updated_at and last_synced_at columns
- Add dedicated "Airtable Metadata Filters" section in UI with date pickers
- Display Airtable updated timestamp in website detail modal
- Integrate seamlessly with existing filter system and search functionality
- Support both frontend UI controls and backend SQL filtering

🤖 Generated with [Claude Code](https://claude.ai/code)