### PR TITLE
feat: Add Website Type and Niche display and filtering to websites di…

### DIFF
--- a/app/websites/page.tsx
+++ b/app/websites/page.tsx
@@ -73,6 +73,8 @@ interface Filters {
   minCost?: number;
   maxCost?: number;
   categories: string[];
+  websiteTypes: string[]; // SaaS, Blog, News, eCommerce, etc.
+  niches: string[]; // Multiple niches
   hasGuestPost?: boolean;
   hasLinkInsert?: boolean;
   status?: string;
@@ -99,10 +101,14 @@ function WebsitesPageContent() {
   const [filters, setFilters] = useState<Filters>({
     search: '',
     categories: [],
+    websiteTypes: [],
+    niches: [],
     qualificationStatus: 'all'
   });
   const [clients, setClients] = useState<Array<{ id: string; name: string }>>([]);
   const [categories, setCategories] = useState<string[]>([]);
+  const [websiteTypes, setWebsiteTypes] = useState<string[]>([]);
+  const [niches, setNiches] = useState<string[]>([]);
   const [selectedWebsiteId, setSelectedWebsiteId] = useState<string | null>(null);
   const [selectedWebsiteDomain, setSelectedWebsiteDomain] = useState<string>('');
   const [showDetailModal, setShowDetailModal] = useState(false);
@@ -125,6 +131,8 @@ function WebsitesPageContent() {
             minCost: filters.minCost,
             maxCost: filters.maxCost,
             categories: filters.categories,
+            websiteTypes: filters.websiteTypes,
+            niches: filters.niches,
             hasGuestPost: filters.hasGuestPost,
             hasLinkInsert: filters.hasLinkInsert,
             status: filters.status,
@@ -196,10 +204,18 @@ function WebsitesPageContent() {
       });
       const data = await response.json();
       const allCategories = new Set<string>();
+      const allWebsiteTypes = new Set<string>();
+      const allNiches = new Set<string>();
+      
       data.websites?.forEach((w: Website) => {
         w.categories?.forEach(cat => allCategories.add(cat));
+        w.websiteType?.forEach(type => allWebsiteTypes.add(type));
+        w.niche?.forEach(niche => allNiches.add(niche));
       });
+      
       setCategories(Array.from(allCategories).sort());
+      setWebsiteTypes(Array.from(allWebsiteTypes).sort());
+      setNiches(Array.from(allNiches).sort());
     } catch (error) {
       console.error('Failed to load categories:', error);
       // Fallback to static list
@@ -634,12 +650,82 @@ function WebsitesPageContent() {
             </div>
           )}
 
+          {/* Website Types */}
+          {showFilters && websiteTypes.length > 0 && (
+            <div className="mt-4">
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                Website Types
+              </label>
+              <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-2">
+                {websiteTypes.map(type => (
+                  <label key={type} className="flex items-center gap-1.5">
+                    <input
+                      type="checkbox"
+                      checked={filters.websiteTypes.includes(type)}
+                      onChange={(e) => {
+                        if (e.target.checked) {
+                          setFilters(prev => ({ 
+                            ...prev, 
+                            websiteTypes: [...prev.websiteTypes, type] 
+                          }));
+                        } else {
+                          setFilters(prev => ({ 
+                            ...prev, 
+                            websiteTypes: prev.websiteTypes.filter(t => t !== type) 
+                          }));
+                        }
+                      }}
+                      className="w-4 h-4 text-purple-600 rounded border-gray-300 focus:ring-purple-500"
+                    />
+                    <span className="text-sm">{type}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Niches */}
+          {showFilters && niches.length > 0 && (
+            <div className="mt-4">
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                Niches
+              </label>
+              <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-2">
+                {niches.map(niche => (
+                  <label key={niche} className="flex items-center gap-1.5">
+                    <input
+                      type="checkbox"
+                      checked={filters.niches.includes(niche)}
+                      onChange={(e) => {
+                        if (e.target.checked) {
+                          setFilters(prev => ({ 
+                            ...prev, 
+                            niches: [...prev.niches, niche] 
+                          }));
+                        } else {
+                          setFilters(prev => ({ 
+                            ...prev, 
+                            niches: prev.niches.filter(n => n !== niche) 
+                          }));
+                        }
+                      }}
+                      className="w-4 h-4 text-orange-600 rounded border-gray-300 focus:ring-orange-500"
+                    />
+                    <span className="text-sm">{niche}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          )}
+
           {showFilters && (
             <div className="mt-4 flex justify-between">
               <button
                 onClick={() => setFilters({ 
                   search: filters.search, 
                   categories: [],
+                  websiteTypes: [],
+                  niches: [],
                   qualificationStatus: 'all' 
                 })}
                 className="text-sm text-gray-600 hover:text-gray-800"
@@ -690,6 +776,12 @@ function WebsitesPageContent() {
                   </th>
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
                     Access
+                  </th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                    Website Type
+                  </th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                    Niche
                   </th>
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
                     Contacts
@@ -781,6 +873,32 @@ function WebsitesPageContent() {
                             <Link2 className="w-3 h-3" />
                             LI
                           </span>
+                        )}
+                      </div>
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex flex-wrap gap-1">
+                        {website.websiteType && website.websiteType.length > 0 ? (
+                          website.websiteType.map((type, index) => (
+                            <span key={index} className="inline-flex items-center text-xs px-2 py-1 bg-purple-100 text-purple-700 rounded">
+                              {type}
+                            </span>
+                          ))
+                        ) : (
+                          <span className="text-gray-400 text-sm">-</span>
+                        )}
+                      </div>
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex flex-wrap gap-1">
+                        {website.niche && website.niche.length > 0 ? (
+                          website.niche.map((niche, index) => (
+                            <span key={index} className="inline-flex items-center text-xs px-2 py-1 bg-orange-100 text-orange-700 rounded">
+                              {niche}
+                            </span>
+                          ))
+                        ) : (
+                          <span className="text-gray-400 text-sm">-</span>
                         )}
                       </div>
                     </td>

--- a/lib/services/airtableSyncService.ts
+++ b/lib/services/airtableSyncService.ts
@@ -270,6 +270,16 @@ export class AirtableSyncService {
       params.push(filters.categories);
     }
     
+    if (filters.websiteTypes && filters.websiteTypes.length > 0) {
+      conditions.push(`w.website_type && $${paramIndex++}`);
+      params.push(filters.websiteTypes);
+    }
+    
+    if (filters.niches && filters.niches.length > 0) {
+      conditions.push(`w.niche && $${paramIndex++}`);
+      params.push(filters.niches);
+    }
+    
     // Airtable metadata filters
     if (filters.airtableUpdatedAfter) {
       conditions.push(`w.airtable_updated_at >= $${paramIndex++}`);

--- a/types/airtable.ts
+++ b/types/airtable.ts
@@ -89,6 +89,8 @@ export interface WebsiteFilters {
   hasGuestPost?: boolean;
   hasLinkInsert?: boolean;
   categories?: string[];
+  websiteTypes?: string[]; // SaaS, Blog, News, eCommerce, etc.
+  niches?: string[]; // Multiple niches
   searchTerm?: string;
   forceAllRecords?: boolean; // Skip view filtering for full sync
   // Airtable metadata filters


### PR DESCRIPTION
…rectory

## Display Enhancements
- Add Website Type column with purple badges showing SaaS, Blog, News, eCommerce, etc.
- Add Niche column with orange badges for multiple niches per website
- Multi-value badge display with flex-wrap layout for readability
- Empty state handling with "-" for websites without type/niche data

## Filter System
- Add Website Types filter section with purple-themed checkboxes
- Add Niches filter section with orange-themed checkboxes
- Dynamic filter population from database - automatically loads unique values
- Multi-select filtering support - filter by multiple types/niches simultaneously
- Integrated with existing clear filters functionality

## Backend Integration
- Update WebsiteFilters interface to include websiteTypes[] and niches[]
- Add SQL filtering conditions using PostgreSQL array operators (&&)
- Efficient filtering with existing GIN indexes on website_type and niche columns
- Frontend-backend parameter passing for new filter types

## User Experience
- Color-coded badges: Purple for Website Types, Orange for Niches
- Consistent grid layout matching existing Categories filter design
- Responsive design with 2-4-6 column breakpoints
- Auto-loading filter options on page initialization

Ready to display and filter Website Type and Niche data from Airtable sync\!

🤖 Generated with [Claude Code](https://claude.ai/code)